### PR TITLE
Fix ambiguity with `get_code_unsafe`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GNSSSignals"
 uuid = "52c80523-2a4e-5c38-8979-05588f836870"
 authors = ["Soeren Zorn <soeren.zorn@nav.rwth-aachen.de>"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/boc.jl
+++ b/src/boc.jl
@@ -9,7 +9,7 @@ end
 """
 $(SIGNATURES)
 
-Get codes of base GNSS system for BOCcos as a Matrix, where each 
+Get codes of base GNSS system for BOCcos as a Matrix, where each
 column represents a PRN.
 """
 function get_codes(boc::AbstractGNSSBOCcos)
@@ -64,7 +64,7 @@ end
 """
 $(SIGNATURES)
 
-Get code of BOC at 
+Get code of BOC at
 phase `phase` of PRN `prn`.
 """
 Base.@propagate_inbounds function get_code(
@@ -86,8 +86,8 @@ end
 $(SIGNATURES)
 
 Get code of type BOC at
-phase `phase` of PRN `prn`. The phase will not be wrapped by the code 
-length. The phase has to be smaller than the code length. 
+phase `phase` of PRN `prn`. The phase will not be wrapped by the code
+length. The phase has to be smaller than the code length.
 """
 Base.@propagate_inbounds function get_code_unsafe(
     boc::AbstractGNSSBOCcos{M, N},
@@ -96,6 +96,15 @@ Base.@propagate_inbounds function get_code_unsafe(
 ) where {M, N}
     floored_phase = floor(Int, phase)
     floored_BOC_phase = floor(Int, phase * 2 * M / N)
-    get_code_unsafe(boc.system, floored_phase, prn) * 
+    get_code_unsafe(boc.system, floored_phase, prn) *
+        (iseven(floored_BOC_phase) << 1 - 1)
+end
+Base.@propagate_inbounds function get_code_unsafe(
+    boc::AbstractGNSSBOCcos{M, N},
+    phase::Integer,
+    prn::Integer
+) where {M, N}
+    floored_BOC_phase = floor(Integer, phase * 2 * M / N)
+    get_code_unsafe(boc.system, phase, prn) *
         (iseven(floored_BOC_phase) << 1 - 1)
 end

--- a/test/boc.jl
+++ b/test/boc.jl
@@ -11,6 +11,8 @@
         @test @inferred(get_data_frequency(boc)) == get_data_frequency(system)
         @test @inferred(get_code_frequency(boc)) == n * get_code_frequency(system)
         @test get_code.(boc, 0:1022, 1) == get_code.(system, 0:1022, 1)
+        @test get_code_unsafe.(boc, 0:1022, 1) == get_code.(system, 0:1022, 1)
+        @test get_code_unsafe.(boc, 0.0:1022.0, 1) == get_code.(system, 0.0:1022.0, 1)
     end
 
     @testset "BOCcos(GPSL1, $m, 1) modulation" for m in [1,2,2.5,5,12.5]


### PR DESCRIPTION
Function `get_code_unsafe` was ambiguous when called as `get_code_unsafe(::AbstractGNSSBOCcos, ::Integer, ::Integer)`. Fixed by implementing explicit version.