### PR TITLE
Shorten `show` output and add `get_system_string` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GNSSSignals"
 uuid = "52c80523-2a4e-5c38-8979-05588f836870"
 authors = ["Soeren Zorn <soeren.zorn@nav.rwth-aachen.de>"]
-version = "0.15.1"
+version = "0.15.2"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/GNSSSignals.jl
+++ b/src/GNSSSignals.jl
@@ -8,6 +8,8 @@ module GNSSSignals
     using CUDA
     const use_gpu = Ref(false)
 
+    import Base.show
+
     export
         AbstractGNSS,
         GPSL1,
@@ -29,6 +31,7 @@ module GNSSSignals
         get_carrier_amplitude_power,
         get_subcarrier_frequency,
         get_code_spectrum,
+        get_system_string,
         fpcarrier_phases!,
         fpcarrier!,
         min_bits_for_code_length,
@@ -39,6 +42,8 @@ module GNSSSignals
     abstract type AbstractGNSSBOCcos{C, M, N} <: AbstractGNSS{C} end
 
     Base.Broadcast.broadcastable(system::AbstractGNSS) = Ref(system)
+
+    Base.show(io::IO, x::AbstractGNSS) = print("$(typeof(x))()")
 
     """
     $(SIGNATURES)

--- a/src/boc.jl
+++ b/src/boc.jl
@@ -6,6 +6,10 @@ function BOCcos(system::T, m, n) where T <: AbstractGNSS
     BOCcos{T, m, n}(system)
 end
 
+function get_system_string(s::BOCcos{T,M,N}) where {T,M,N}
+    "BOCcos($(get_system_string(s.system)), $M, $N)"
+end
+
 """
 $(SIGNATURES)
 

--- a/src/galileo_e1b.jl
+++ b/src/galileo_e1b.jl
@@ -9,6 +9,8 @@ struct GalileoE1B{C <: AbstractMatrix} <: AbstractGNSSBOCcos{C, 1, 1}
     system::GalileoE1BBase{C}
 end
 
+get_system_string(s::GalileoE1B) = "GalileoE1B"
+
 function read_from_documentation(raw_code)
     raw_code_without_spaces = replace(replace(raw_code, " " => ""), "\n" => "")
     code_hex_array = map(x -> parse(UInt16, x, base = 16), collect(raw_code_without_spaces))

--- a/src/gps_l1.jl
+++ b/src/gps_l1.jl
@@ -2,6 +2,8 @@ struct GPSL1{C <: AbstractMatrix} <: AbstractGNSS{C}
     codes::C
 end
 
+get_system_string(s::GPSL1) = "GPSL1"
+
 function read_gpsl1_codes()
     read_in_codes(
         Int8,

--- a/src/gps_l5.jl
+++ b/src/gps_l5.jl
@@ -2,6 +2,8 @@ struct GPSL5{C <: AbstractMatrix} <: AbstractGNSS{C}
     codes::C
 end
 
+get_system_string(s::GPSL5) = "GPSL5"
+
 #=These are the initial XB Code States for the I5 code,
 initial_xb_code_states[1] is a 1 3 chip array which represent the shift
 register values initial_xb_code_states[3][4] represents the 4th shift register

--- a/test/boc.jl
+++ b/test/boc.jl
@@ -1,6 +1,5 @@
 @testset "BOCcos" begin
-
-    @testset "BOCcos($system, 0, $n)" for system in [GPSL1()], n in [1]#[GPSL1(), GPSL5(), GalileoE1B()], n in [1, 5, 10]
+    @testset "BOCCos($(get_system_string(system)), 0, $n)" for system in [GPSL1()], n in [1]#[GPSL1(), GPSL5(), GalileoE1B()], n in [1, 5, 10]
         boc = BOCcos(system, 0, n)
         @test @inferred(get_center_frequency(boc)) == get_center_frequency(system)
         @test @inferred(get_code_length(boc)) == get_code_length(system)

--- a/test/common.jl
+++ b/test/common.jl
@@ -2,7 +2,7 @@
     @test get_code_center_frequency_ratio(GPSL1()) ≈ 1/1540
 end
 
-@testset "Code spectra $(system)" for system = [GPSL1(), GPSL5(), BOCcos(GPSL1(),0,15)]
+@testset "Code spectra $(get_system_string(system))" for system = [GPSL1(), GPSL5(), BOCcos(GPSL1(),0,15)]
     @test get_code_spectrum(system, 0) ≈ 1.0Hz/get_code_frequency(system)
     @testset "Test $(m). zero" for m = 1:10
         @test get_code_spectrum(system, m*get_code_frequency(system)) == 0
@@ -11,7 +11,7 @@ end
     @test sum(get_code_spectrum.(system, -1e12:1e4:1e12))*1e4 ≈ 1 rtol = 1e-5
 end
 
-@testset "Code spectra $(system)" for system = [GalileoE1B(), BOCcos(GPSL1(),15,2.5)]
+@testset "Code spectra $(get_system_string(system))" for system = [GalileoE1B(), BOCcos(GPSL1(),15,2.5)]
     @test get_code_spectrum(system, 0) == 0.0
     @test sum(get_code_spectrum.(system, -1e12:1e4:1e12))*1e4 ≈ 1 rtol = 1e-5
 end


### PR DESCRIPTION
Currently, `show(x)` not only prints the system type, but also the internal PRN-Codes to repl. This is quite lengthy and thus, the codes are removed from output of show. Besides, the `get_system_string(x)` method is added in order to get an even shorter system description.