### PR TITLE
Generate code with a start index

### DIFF
--- a/src/GNSSSignals.jl
+++ b/src/GNSSSignals.jl
@@ -18,6 +18,7 @@ module GNSSSignals
         GalileoE1B,
         BOCcos,
         gen_code!,
+        gen_code,
         get_codes,
         get_code_length,
         get_secondary_code_length,

--- a/src/common.jl
+++ b/src/common.jl
@@ -32,13 +32,14 @@ function gen_code!(
     num_samples = length(code)
     fixed_point = sizeof(Int) * 8 - 1 - min_bits_for_code_length(gnss)
     FP = Fixed{Int, fixed_point}
-    total_code_length = FP(get_code_length(gnss) * get_secondary_code_length(gnss))
+    total_code_length = get_code_length(gnss) * get_secondary_code_length(gnss)
+    fp_total_code_length = FP(total_code_length)
     delta = FP(code_frequency / sampling_frequency)
-    code_phase = mod(FP(start_phase) + start_index * delta, total_code_length)
+    code_phase = FP(mod(FP(mod(start_phase, total_code_length)) + start_index * delta, total_code_length))
     @inbounds for i ∈ 1:num_samples
         code[i] = get_code_unsafe(gnss, code_phase, prn)
         code_phase += delta
-        code_phase -= (code_phase >= total_code_length) * total_code_length
+        code_phase -= (code_phase >= fp_total_code_length) * fp_total_code_length
     end
     return code
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -26,6 +26,17 @@ end
     @test code == gen_code(samples, system, 1, sampling_rate, get_code_frequency(system), 0)
 end
 
+@testset "Code generation with start_phase bigger than code_length" begin
+    system = GPSL1()
+    sampling_rate = 2.5e6Hz
+    samples = 2500
+    code = zeros(Int16, samples)
+    code = gen_code!(code, system, 1, sampling_rate, get_code_frequency(system), 2065)
+    phase = (0:samples - 1) * get_code_frequency(system) / sampling_rate .+ 2065
+    @test code == get_code.(system, phase, 1)
+    @test code == gen_code(samples, system, 1, sampling_rate, get_code_frequency(system), 2065)
+end
+
 @testset "Code generation $(get_system_string(system)) with different index" for system = [GalileoE1B(), GPSL1(), GPSL5()]
     sampling_rate = 25e6Hz
     samples = 4002

--- a/test/common.jl
+++ b/test/common.jl
@@ -5,15 +5,15 @@ end
 @testset "Code spectra $(get_system_string(system))" for system = [GPSL1(), GPSL5(), BOCcos(GPSL1(),0,15)]
     @test get_code_spectrum(system, 0) ≈ 1.0Hz/get_code_frequency(system)
     @testset "Test $(m). zero" for m = 1:10
-        @test get_code_spectrum(system, m*get_code_frequency(system)) == 0
-        @test get_code_spectrum(system, -m*get_code_frequency(system)) == 0
+        @test get_code_spectrum(system, m * get_code_frequency(system)) == 0
+        @test get_code_spectrum(system, -m * get_code_frequency(system)) == 0
     end
-    @test sum(get_code_spectrum.(system, -1e12:1e4:1e12))*1e4 ≈ 1 rtol = 1e-5
+    @test sum(get_code_spectrum.(system, -1e12:1e4:1e12)) * 1e4 ≈ 1 rtol = 1e-5
 end
 
 @testset "Code spectra $(get_system_string(system))" for system = [GalileoE1B(), BOCcos(GPSL1(),15,2.5)]
     @test get_code_spectrum(system, 0) == 0.0
-    @test sum(get_code_spectrum.(system, -1e12:1e4:1e12))*1e4 ≈ 1 rtol = 1e-5
+    @test sum(get_code_spectrum.(system, -1e12:1e4:1e12)) * 1e4 ≈ 1 rtol = 1e-5
 end
 
 @testset "Code generation $(get_system_string(system))" for system = [GalileoE1B(), GPSL1(), GPSL5()]
@@ -21,6 +21,17 @@ end
     samples = 1000
     code = zeros(Int16, samples)
     code = gen_code!(code, system, 1, sampling_rate, get_code_frequency(system), 0)
-    phase = (0:length(code)-1)/sampling_rate * get_code_frequency(system)
+    phase = (0:length(code) - 1) * get_code_frequency(system) / sampling_rate
     @test code == get_code.(system, phase, 1)
+    @test code == gen_code(samples, system, 1, sampling_rate, get_code_frequency(system), 0)
+end
+
+@testset "Code generation $(get_system_string(system)) with different index" for system = [GalileoE1B(), GPSL1(), GPSL5()]
+    sampling_rate = 25e6Hz
+    samples = 4002
+    code = zeros(Int16, samples)
+    code = gen_code!(code, system, 1, sampling_rate, get_code_frequency(system), 0.0, -1)
+    phase = (-1:4000) * get_code_frequency(system) / sampling_rate
+    @test code == get_code.(system, phase, 1)
+    @test code == gen_code(samples, system, 1, sampling_rate, get_code_frequency(system), 0.0, -1)
 end


### PR DESCRIPTION
In Tracking.jl we used to call `gen_code!` with `start_phase = start_code_phase + most_late_sample_shift * code_frequency / sampling_frequency` where `code_frequency` and `sampling_frequency` are floats.
However, inside `gen_code` we calculate the increment `delta` with fixed point numbers.
Therefore, in some cases `code_frequency / sampling_frequency` and `delta` were different, which leads to index errors.

With this change you can specify the `start_index`. In this case both `delta`s are guaranteed to be the same.
A pull request to Tracking.jl will follow, once this is merged.

**EDIT**: I also added a convenient non-inplace function for gen_code and removed some code duplication.