### PR TITLE
test: pass maximum sampling frequency as val to benchmark

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -38,7 +38,7 @@ jobs:
                 echo $PATH
                 ls -l ~/.julia/bin
                 mkdir results
-                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.repository.default_branch}}" --output-dir=results/ --add Unitful --tune
+                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --output-dir=results/ --add Unitful --tune
             - name: Create plots from benchmarks
               run: |
                 mkdir -p plots

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -7,15 +7,33 @@ const SUITE = BenchmarkGroup()
 num_samples = 2000
 sampled_code = zeros(Int16, num_samples)
 
-SUITE["code"]["code generation"]["GPSL1"] =
-    @benchmarkable gen_code!($sampled_code, $(GPSL1()), $1, $(2e6Hz)) evals = 10 samples =
-        10000
+SUITE["code"]["code generation"]["GPSL1"] = @benchmarkable gen_code!(
+    $sampled_code,
+    $(GPSL1()),
+    $1,
+    $(2e6Hz),
+    $0.0,
+    $0,
+    $(Val(2e6Hz)),
+) evals = 10 samples = 10000
 
-SUITE["code"]["code generation"]["GPSL5"] =
-    @benchmarkable gen_code!($sampled_code, $(GPSL5()), $1, $(20e6Hz)) evals = 10 samples =
-        10000
+SUITE["code"]["code generation"]["GPSL5"] = @benchmarkable gen_code!(
+    $sampled_code,
+    $(GPSL5()),
+    $1,
+    $(20e6Hz),
+    $0.0,
+    $0,
+    $(Val(20e6Hz)),
+) evals = 10 samples = 10000
 
 sampled_code_f32 = zeros(Float32, num_samples)
-SUITE["code"]["code generation"]["GalileoE1B"] =
-    @benchmarkable gen_code!($sampled_code_f32, $(GalileoE1B()), $1, $(15e6Hz)) evals = 10 samples =
-        10000
+SUITE["code"]["code generation"]["GalileoE1B"] = @benchmarkable gen_code!(
+    $sampled_code_f32,
+    $(GalileoE1B()),
+    $1,
+    $(15e6Hz),
+    $0.0,
+    $0,
+    $(Val(15e6Hz)),
+) evals = 10 samples = 10000


### PR DESCRIPTION
By providing the maximum sampling frequency as Val to code generation, the performance will be even faster.