### PR TITLE
fix(l1c_d): report channel symbol rate (100 Hz), not info bit rate (50 Hz)

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -88,7 +88,7 @@ get_secondary_code(gpsl5i)        # (1, 1, 1, 1, -1, -1, 1, -1, 1, -1)
 
 ### GPS L1C-D
 
-GPS L1C-D is the data-carrying component of GPS L1C (IS-GPS-800G). It uses BOC(1,1) modulation with a 10230-chip Weil-based primary code and carries CNAV-2 data at 50 sps. It is broadcast by Block III/IIIF satellites and supports PRNs 1-63:
+GPS L1C-D is the data-carrying component of GPS L1C (IS-GPS-800G). It uses BOC(1,1) modulation with a 10230-chip Weil-based primary code and broadcasts the CNAV-2 message at 100 sps (post-LDPC channel symbol rate; the information bit rate after rate-½ decoding is 50 bps). It is broadcast by Block III/IIIF satellites and supports PRNs 1-63:
 
 ```julia
 gpsl1c_d = GPSL1C_D()
@@ -96,7 +96,7 @@ get_code_length(gpsl1c_d)           # 10230
 get_band(gpsl1c_d)                  # L1()
 get_center_frequency(gpsl1c_d)      # 1575420000 Hz
 get_code_frequency(gpsl1c_d)        # 1023000 Hz
-get_data_frequency(gpsl1c_d)        # 50 Hz
+get_data_frequency(gpsl1c_d)        # 100 Hz
 get_secondary_code_length(gpsl1c_d) # 1 (no secondary code)
 get_modulation(gpsl1c_d)            # BOCsin(1, 1)
 ```

--- a/src/gps/l1c_d.jl
+++ b/src/gps/l1c_d.jl
@@ -7,7 +7,10 @@ Block III/IIIF satellites alongside the legacy L1 C/A).
 BOC(1,1) sine-phased on the L1 band (1575.42 MHz). 10230-chip primary
 code at 1.023 Mcps, derived from a Weil-code construction with a 7-chip
 expansion inserted at a PRN-specific point (IS-GPS-800G §3.2.2.1.1).
-No secondary code; carries the CNAV-2 message at 50 sps.
+No secondary code; carries the CNAV-2 message at 100 sps (50 bps after
+rate-½ LDPC decoding, per IS-GPS-800G §3.2.3 — `get_data_frequency`
+exposes the broadcast symbol rate, matching the convention used for all
+other GPS / Galileo signals in this package).
 
 # Example
 ```julia
@@ -81,9 +84,16 @@ Get the code chipping rate for GPS L1C-D.
 """
 $(SIGNATURES)
 
-Get the data bit rate for GPS L1C-D.
+Get the symbol rate of the CNAV-2 message broadcast on GPS L1C-D.
+
+Per IS-GPS-800G §3.2.3, each frame of 9 + 1200 + 548 + 24 + 24 - 5 = 1800
+LDPC-encoded symbols is broadcast at 100 sps. The post-decode
+information bit rate is 50 bps (rate-½ LDPC), but `get_data_frequency`
+returns the broadcast symbol rate to stay consistent with the other
+signals in this package — e.g. GPS L5I and Galileo E1B both report the
+post-FEC channel symbol rate, not the pre-FEC information rate.
 
 # Returns
-- `Frequency`: 50 Hz (CNAV-2)
+- `Frequency`: 100 Hz
 """
-@inline get_data_frequency(::GPSL1C_D) = 50Hz
+@inline get_data_frequency(::GPSL1C_D) = 100Hz

--- a/test/gps/l1c_d.jl
+++ b/test/gps/l1c_d.jl
@@ -5,7 +5,7 @@
     @test @inferred(get_code_length(sig)) == 10230
     @test @inferred(get_secondary_code_length(sig)) == 1
     @test @inferred(get_secondary_code(sig)) isa NoSecondaryCode
-    @test @inferred(get_data_frequency(sig)) == 50Hz
+    @test @inferred(get_data_frequency(sig)) == 100Hz
     @test @inferred(get_code_frequency(sig)) == 1023e3Hz
     @test @inferred(get_modulation(sig)) == GNSSSignals.BOCsin(1, 1)
     @test get_signal_name(sig) == "GPS L1C-D"


### PR DESCRIPTION
## Summary

- `get_data_frequency(::GPSL1C_D)` returned 50 Hz (the post-LDPC information bit rate). Per IS-GPS-800G §3.2.3 the CNAV-2 frame is broadcast onto the carrier at **100 sps** — one channel symbol per 10 ms primary code period.
- Every other signal in this package reports the broadcast channel symbol rate:
  - GPS L1 C/A: 50 Hz (no FEC)
  - GPS L5I: 100 Hz (rate-½ conv. of 50 bps NAV → 100 sps)
  - Galileo E1B / E1B_BOC11: 250 Hz (rate-½ conv. of 125 bps I/NAV → 250 sps)
  - GPS L1C-P: 0 Hz (pilot)
- L1C-D was the only outlier; downstream code computing primary-blocks-per-symbol from `get_code_frequency / (get_code_length * get_data_frequency)` was getting 2 instead of 1, which is wrong for bit/symbol-sync logic.

## Changes

- `src/gps/l1c_d.jl`: `get_data_frequency` returns `100Hz`; docstring rewritten to spell out the symbol-rate vs. info-rate convention and cite IS-GPS-800G §3.2.3.
- `test/gps/l1c_d.jl`: assertion updated.
- `docs/src/usage.md`: example output updated; prose clarified that 100 sps is the broadcast symbol rate and 50 bps is the post-LDPC info rate.

## Test plan

- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — full suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)