### PR TITLE
fix(common): prevent Int64 overflow in sample_code! for very short outputs

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -202,7 +202,20 @@ function sample_code!(
     # delta_sum accumulates (num_samples * frequency_ratio) in fixed-point representation.
     # With -1, delta_sum uses nearly the full Int range and can overflow when combined
     # with the (1 << fixed_point) offset in the initial delta_sum calculation.
-    fixed_point = sizeof(Int) * 8 - 2 - ndigits(length(sampled_code); base = 2)
+    #
+    # We must also reserve bits for the integer part of `frequency_ratio`:
+    # `frequency_ratio_fixed_point = frequency_ratio * 2^fixed_point` overflows
+    # Int64 otherwise. For long outputs `ndigits(length)` dominates and this is
+    # a no-op; for very short outputs (a handful of samples, e.g. the tiny
+    # integration windows of multi-signal tracking) it keeps the exponent low
+    # enough that the multiply stays in range. Taking the max only ever lowers
+    # `fixed_point`, so the accumulation headroom above is preserved. See
+    # https://github.com/JuliaGNSS/GNSSSignals.jl/issues/63.
+    fixed_point =
+        sizeof(Int) * 8 - 2 - max(
+            ndigits(length(sampled_code); base = 2),
+            ndigits(ceil(Int, frequency_ratio); base = 2),
+        )
 
     frequency_ratio_fixed_point = round(Int, frequency_ratio * 1 << fixed_point)
 

--- a/test/common.jl
+++ b/test/common.jl
@@ -296,6 +296,29 @@ end
     @test code ≈ get_code.(signal, phase, 1)
 end
 
+# Regression test for the fixed-point overflow on very short outputs
+# (https://github.com/JuliaGNSS/GNSSSignals.jl/issues/63): a handful of
+# samples makes `ndigits(length)` tiny, so the fixed-point exponent grows
+# until `frequency_ratio * 2^exponent` overflows Int64. High sampling rate
+# (large frequency_ratio) is the worst case. Such tiny requests arise in
+# multi-signal tracking when two signals' code-block boundaries nearly
+# coincide.
+@testset "Very short code generation does not overflow $(get_signal_name(signal))" for signal in [
+    GalileoE1B(),
+    GPSL1CA(),
+    GPSL5I(),
+]
+    sampling_rate = 25e6Hz
+    for samples in (1, 2, 3, 5)
+        code = zeros(get_code_type(signal), samples)
+        code = @test_nowarn gen_code!(
+            code, signal, 1, sampling_rate, get_code_frequency(signal), 3.5,
+        )
+        phase = (0:samples-1) * get_code_frequency(signal) / sampling_rate .+ 3.5
+        @test code ≈ get_code.(signal, phase, 1)
+    end
+end
+
 @testset "Code generation for different units" begin
     sampling_rate = 25MHz
     signal = GPSL1CA()


### PR DESCRIPTION
Fixes #63.

## Problem

`sample_code!` picks its fixed-point fractional-bit count from the output length only:

```julia
fixed_point = sizeof(Int) * 8 - 2 - ndigits(length(sampled_code); base = 2)
frequency_ratio_fixed_point = round(Int, frequency_ratio * 1 << fixed_point)
```

For a very short output, `ndigits(length)` is small, so `fixed_point` approaches ~60. Because the integer part of `frequency_ratio` (≥ 1) is not reserved for, `frequency_ratio * 2^fixed_point` overflows `Int64` and `round(Int, …)` throws `InexactError`. This is latent for normal (long) requests but surfaces in multi-signal tracking, where the per-call code replica can shrink to one or two samples when two signals' code-block boundaries nearly coincide.

## Fix

Reserve bits for the integer part of `frequency_ratio` as well, by taking the max of the two bit-widths:

```julia
fixed_point = sizeof(Int) * 8 - 2 - max(
    ndigits(length(sampled_code); base = 2),
    ndigits(ceil(Int, frequency_ratio); base = 2),
)
```

`max` only ever **lowers** `fixed_point`, so the `delta_sum` accumulation headroom is preserved and long-output behaviour is unchanged — it just keeps the fixed-point multiply in range for short outputs.

## Test

Test-first: the added `Very short code generation does not overflow` testset (1–5 samples at 25 MHz for Galileo E1B, GPS L1 C/A, GPS L5-I) errors on the current code and passes with the fix. Full suite is green.