### PR TITLE
perf: broadcast run-fill for high-oversampling LUT code generation

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,6 @@
 using BenchmarkTools
 using GNSSSignals
-using SIMD: Vec, vload, shufflevector
+using SIMD: Vec, vload, vstore, shufflevector
 import SinCosLUT
 using SinCosLUT: SinCosTable, generate_carrier!, cycles_per_sample,
                  carrier_engine, carrier_state, carrier_lookup, carrier_advance, carrier_width
@@ -189,16 +189,18 @@ end
 # SHARED CARRIER WIPE-OFF. The carrier is identical for all three correlators, so the
 # per-sample wipe DI = mᵣ·cos + mᵢ·sin, DQ = mᵢ·cos − mᵣ·sin is computed ONCE and each
 # correlator reduces to a cheap Σ codeₓ·DI / Σ codeₓ·DQ — ~1.8× faster than three
-# independent correlations. The wipe is a per-sample complex multiply: deinterleave mᵣ/mᵢ,
-# widen everything to Int32 and multiply (per-sample products reach 2048·8·2 = 32768 > Int16,
-# so DI/DQ are Int32). The code step is then an Int32 multiply (code ±1, CBOC/BOC ±2) into the
-# accumulators. NOTE: `vpmaddwd` is deliberately NOT used here. It packs an Int16×Int16→Int32
-# *pairwise sum*, which only pays off when the output is a reduced sum; the wipe output is
-# per-sample, so the interleave + shuffles `vpmaddwd` needs are pure overhead — the straight
-# deinterleave-and-multiply is ~17–25 % faster (measured on AVX-512) and identical on NEON,
-# which has no `vpmaddwd` anyway. (Keeping DI/DQ in Int16 to re-enable `vpmaddwd` for the code
-# step was tried and is a wash: the kernel is bound by the lookup/shuffle work, not the
-# multiply width.)
+# independent correlations. The wipe is a per-sample complex multiply: deinterleave mᵣ/mᵢ and
+# multiply by the carrier. The arithmetic width is chosen at compile time (see `choose_carrier`):
+#   • Int16 fast path — when 2·max|meas|·amplitude ≤ typemax(Int16) (true for the 12-bit ADC at the
+#     auto-chosen amplitude), DI/DQ stay Int16 (`vpmullw`, half the AVX register width). The code
+#     step Σ codeₓ·DI is then a `vpmaddwd` (Int16×Int16→Int32 pairwise-add) — a dot-product reduction
+#     into half-width accumulators. NOTE: `vpmaddwd` pays off for the *reduced-sum* code step, but
+#     NOT for the per-sample wipe (its tiling shuffles + 4× carrier bandwidth lose there — measured);
+#     so the wipe stays a straight deinterleave-multiply. Net ~2× on AVX-512, ~1.2× on AVX2.
+#   • Int32 fallback — exact for any amplitude (per-sample products can reach 2048·127·2 > Int16), and
+#     the only path on NEON/portable (no `vpmaddwd`). Deinterleave, widen to Int32, `vpmulld`.
+# Both paths are bit-identical (the Int16 path provably cannot overflow when selected). The
+# amplitude is auto-maximised within the Int16-safe bound, so a coarser ADC keeps a finer carrier.
 #
 # EARLY/LATE = PROMPT SHIFTED BY D SAMPLES. One Prompt code stream is built; Early/Late index
 # it ∓D samples away. This generates the code ONCE (N+2D samples) instead of three times and
@@ -234,30 +236,118 @@ const _CORR_W = let be = SinCosLUT.default_backend(Int8, 64)
     be isa SinCosLUT.AVX2 ? 32 :
     be isa SinCosLUT.Neon ? 16 : 1
 end
+# Strip-mining block length (samples) for the "hybrid-blocked" kernel below. A multiple of every
+# backend `W`; sized so its three L1-resident scratch buffers (≈ 3·_CORR_BLK bytes per channel)
+# stay in L1 and are reused across blocks rather than spilling to the LLC.
+const _CORR_BLK = 8192
+
+# ── Int16 carrier-wipe fast path ────────────────────────────────────────────
+# The shared wipe DI = mᵣ·cos + mᵢ·sin / DQ = mᵢ·cos − mᵣ·sin is the dominant per-sample cost.
+# It can run entirely in Int16 (half the AVX register width of the Int32 form — and feeding a
+# `vpmaddwd` code accumulate) *iff* it cannot overflow: |DI| ≤ 2·max|meas|·amplitude ≤ typemax(Int16).
+# `vpmaddwd` exists on AVX2/AVX-512 only, so the fast path is gated on the backend too.
+const _HAS_MADDWD = _CORR_W in (32, 64)        # AVX2 (W=32) / AVX-512 (W=64)
+
+# Pick (carrier amplitude, wipe intermediate type) for a declared maximum |measurement component|.
+# REQUIRED input, NO default: under-declaring `max_meas` would silently overflow the Int16 wipe and
+# corrupt results, while over-declaring only forgoes the speedup. We take the LARGEST Int16-safe
+# amplitude (carrier rounding error is ±0.5 regardless of amplitude, so relative error ≈ 0.5/amp —
+# bigger amp = finer carrier), capped at the Int8 storage limit. If no amplitude ≥1 is safe (very
+# large `max_meas`) or the backend lacks `vpmaddwd`, fall back to the exact Int32 wipe at full Int8
+# amplitude (Int32 has the headroom, so best fidelity there).
+function choose_carrier(max_meas::Integer)
+    _HAS_MADDWD || return (Int(typemax(Int8)), Int32)
+    a = Int(typemax(Int16)) ÷ (2 * Int(max_meas))           # ⌊32767 / (2·max_meas)⌋, may be 0
+    a >= 1 ? (min(a, Int(typemax(Int8))), Int16) : (Int(typemax(Int8)), Int32)
+end
+
+# The benchmark measurement is a 12-bit ADC sample, so |meas| ≤ 2^11. One source of truth for the
+# carrier amplitude + wipe type, shared by every kernel so all four stay mutually bit-identical.
+const _ADC_BITS = 12
+const _MAX_MEAS = 1 << (_ADC_BITS - 1)                       # 2048
+const _CARRIER_AMP, _WIPE_TI = choose_carrier(_MAX_MEAS)     # (7, Int16) on AVX2/AVX-512
 
 @inline _wide32(v::Vec{W,Int8}) where {W} = convert(Vec{W,Int32}, v)
 @inline _wide32(v::Vec{W,Int16}) where {W} = convert(Vec{W,Int32}, v)
+@inline _wide16(v::Vec{W,Int8}) where {W} = convert(Vec{W,Int16}, v)
 
 # Deinterleave [re, im, …] → real (even lanes) / imag (odd lanes), Vec{2W,Int16} → Vec{W,Int16}.
 @inline _re(v::Vec{M,Int16}) where {M} = shufflevector(v, Val(ntuple(i -> 2 * (i - 1), Val(M ÷ 2))))
 @inline _im(v::Vec{M,Int16}) where {M} = shufflevector(v, Val(ntuple(i -> 2 * (i - 1) + 1, Val(M ÷ 2))))
 
-# Per-sample shared carrier wipe (interleaved meas + sin/cos Int8) → (DI, DQ)::Vec{W,Int32}:
-# deinterleave mᵣ/mᵢ, widen to Int32, multiply. Same expressions on every backend (no intrinsic).
-@inline function _wipe(v::Vec{M,Int16}, sinv, cosv) where {M}
+# ── vpmaddwd: Int16×Int16 → Int32 pairwise-add — the dot-product primitive for the code accumulate
+# Σ codeₓ·DI. Native 512-/256-bit intrinsics tiled to width W; x86-only (the Int16 path is gated on
+# `_HAS_MADDWD`, so these are never instantiated on other backends). Output is Vec{W÷2,Int32}
+# (adjacent samples pre-summed); the final `sum` over the accumulator is identical to a per-lane
+# Int32 reduction (integer addition is associative), so the result is bit-exact with the Int32 path.
+@static if Sys.ARCH in (:x86_64, :i686)
+    @inline _madd_tile(a::Vec{M,Int16}, ::Val{o}, ::Val{t}) where {M,o,t} =
+        shufflevector(a, Val(ntuple(i -> i - 1 + o, Val(t))))
+    @inline function _madd512(a::Vec{32,Int16}, b::Vec{32,Int16})
+        Vec(Base.llvmcall(("""
+            declare <16 x i32> @llvm.x86.avx512.pmaddw.d.512(<32 x i16>, <32 x i16>)
+            define <16 x i32> @entry(<32 x i16> %a, <32 x i16> %b) #0 {
+              %r = call <16 x i32> @llvm.x86.avx512.pmaddw.d.512(<32 x i16> %a, <32 x i16> %b)
+              ret <16 x i32> %r }
+            attributes #0 = { alwaysinline }""", "entry"), NTuple{16,Base.VecElement{Int32}},
+            Tuple{NTuple{32,Base.VecElement{Int16}}, NTuple{32,Base.VecElement{Int16}}}, a.data, b.data))
+    end
+    @inline function _madd256(a::Vec{16,Int16}, b::Vec{16,Int16})
+        Vec(Base.llvmcall(("""
+            declare <8 x i32> @llvm.x86.avx2.pmadd.wd(<16 x i16>, <16 x i16>)
+            define <8 x i32> @entry(<16 x i16> %a, <16 x i16> %b) #0 {
+              %r = call <8 x i32> @llvm.x86.avx2.pmadd.wd(<16 x i16> %a, <16 x i16> %b)
+              ret <8 x i32> %r }
+            attributes #0 = { alwaysinline }""", "entry"), NTuple{8,Base.VecElement{Int32}},
+            Tuple{NTuple{16,Base.VecElement{Int16}}, NTuple{16,Base.VecElement{Int16}}}, a.data, b.data))
+    end
+    @inline function _maddacc(a::Vec{64,Int16}, b::Vec{64,Int16})        # AVX-512: 2×512-bit tiles
+        lo = _madd512(_madd_tile(a, Val(0), Val(32)),  _madd_tile(b, Val(0), Val(32)))
+        hi = _madd512(_madd_tile(a, Val(32), Val(32)), _madd_tile(b, Val(32), Val(32)))
+        shufflevector(lo, hi, Val(ntuple(i -> i - 1, Val(32))))
+    end
+    @inline function _maddacc(a::Vec{32,Int16}, b::Vec{32,Int16})        # AVX2: 2×256-bit tiles
+        lo = _madd256(_madd_tile(a, Val(0), Val(16)),  _madd_tile(b, Val(0), Val(16)))
+        hi = _madd256(_madd_tile(a, Val(16), Val(16)), _madd_tile(b, Val(16), Val(16)))
+        shufflevector(lo, hi, Val(ntuple(i -> i - 1, Val(16))))
+    end
+end
+
+# Per-sample shared carrier wipe → (DI, DQ). Two paths, selected at compile time by the wipe type:
+#   Int32 — deinterleave mᵣ/mᵢ, widen to Int32, multiply. Exact for any amplitude; the fallback.
+#   Int16 — same but stays in Int16 (vpmullw), valid only when 2·max|meas|·amplitude ≤ typemax(Int16)
+#           (see `choose_carrier`). Half the register width on AVX, and feeds the vpmaddwd accumulate.
+@inline function _wipe(::Type{Int32}, v::Vec{M,Int16}, sinv::Vec{W,Int8}, cosv::Vec{W,Int8}) where {M,W}
     mr = _wide32(_re(v)); mi = _wide32(_im(v)); cs = _wide32(cosv); sn = _wide32(sinv)
     (mr * cs + mi * sn, mi * cs - mr * sn)
 end
+@inline function _wipe(::Type{Int16}, v::Vec{M,Int16}, sinv::Vec{W,Int8}, cosv::Vec{W,Int8}) where {M,W}
+    mr = _re(v); mi = _im(v); cs = _wide16(cosv); sn = _wide16(sinv)
+    (mr * cs + mi * sn, mi * cs - mr * sn)
+end
 
-# Accumulate one chunk into the six Int32 E/P/L accumulators (code ±1/±2 × Int32 DI/DQ).
-@inline _accum_epl(IE, QE, IP, QP, IL, QL, cE, cP, cL, DI, DQ) =
-    (IE + cE * DI, QE + cE * DQ, IP + cP * DI, QP + cP * DQ, IL + cL * DI, QL + cL * DQ)
+# Six E/P/L accumulators as a tuple (IE,QE,IP,QP,IL,QL); `_acc_zeros`/`_acc_sum` bracket the loop
+# and `_acc` folds one chunk. The accumulate dispatches on the DI/DQ element type the wipe produced:
+#   Int32 DI → widen code to Int32, vpmulld into full-width (Vec{W,Int32}) accumulators.
+#   Int16 DI → widen code to Int16, vpmaddwd into half-width (Vec{W÷2,Int32}) accumulators.
+@inline _acc_zeros(::Type{Int32}, ::Val{W}) where {W} = ntuple(_ -> zero(Vec{W,Int32}), Val(6))
+@inline _acc_zeros(::Type{Int16}, ::Val{W}) where {W} = ntuple(_ -> zero(Vec{W ÷ 2,Int32}), Val(6))
+@inline _acc_sum(a) = ((sum(a[1]), sum(a[2])), (sum(a[3]), sum(a[4])), (sum(a[5]), sum(a[6])))
+@inline function _acc(a, cE::Vec{W,Int8}, cP::Vec{W,Int8}, cL::Vec{W,Int8}, DI::Vec{W,Int32}, DQ::Vec{W,Int32}) where {W}
+    e = _wide32(cE); p = _wide32(cP); l = _wide32(cL)
+    (a[1] + e * DI, a[2] + e * DQ, a[3] + p * DI, a[4] + p * DQ, a[5] + l * DI, a[6] + l * DQ)
+end
+@inline function _acc(a, cE::Vec{W,Int8}, cP::Vec{W,Int8}, cL::Vec{W,Int8}, DI::Vec{W,Int16}, DQ::Vec{W,Int16}) where {W}
+    e = _wide16(cE); p = _wide16(cP); l = _wide16(cL)
+    (a[1] + _maddacc(e, DI), a[2] + _maddacc(e, DQ), a[3] + _maddacc(p, DI),
+     a[4] + _maddacc(p, DQ), a[5] + _maddacc(l, DI), a[6] + _maddacc(l, DQ))
+end
 
 # ── FUSED E/P/L: one Prompt code lookup per chunk; Early/Late are lane-shifts across a sliding
 # pipeline of P = ⌈D/W⌉+⌊D/W⌋+2 carried code chunks. `@generated` so the pipeline length, the
 # per-correlator chunk indices and the shuffle masks fold to literals (fully unrolled, 0-alloc)
 # for any (W, D). The Prompt code is a single value-based stream; nothing is materialised.
-@generated function correlate_epl_fused(meas::Vector{Int16}, ceng1, reng, ::Val{W}, ::Val{D}) where {W,D}
+@generated function correlate_epl_fused(meas::Vector{Int16}, ceng1, reng, ::Val{W}, ::Val{D}, ::Val{TI}) where {W,D,TI}
     g = cld(D, W); fl = fld(D, W); P = g + fl + 2
     re = g * W - D; rl = D - fl * W
     csym = Vector{Symbol}(undef, P); for i in 1:P; csym[i] = Symbol(:c_, i); end
@@ -272,22 +362,20 @@ end
     for i in 1:P-1; push!(shift, :($(csym[i]) = $(csym[i+1]))); end
     push!(shift, :($(csym[P]) = code_lookup(ceng1, cs))); push!(shift, :(cs = code_advance(ceng1, cs)))
     quote
-        IE = zero(Vec{$W,Int32}); QE = zero(Vec{$W,Int32}); IP = zero(Vec{$W,Int32})
-        QP = zero(Vec{$W,Int32}); IL = zero(Vec{$W,Int32}); QL = zero(Vec{$W,Int32})
+        acc = _acc_zeros($TI, Val($W))
         cs = code_state(ceng1, 0); rs = carrier_state(reng, 0); z = zero(Vec{$W,Int8})
         $(prime...)
         n = 0; lim = length(meas) ÷ 2
         @inbounds while n < lim
             sinv, cosv = carrier_lookup(reng, rs); rs = carrier_advance(reng, rs, 1)
-            DI, DQ = _wipe(vload(Vec{$(2W),Int16}, meas, 2n + 1), sinv, cosv)
+            DI, DQ = _wipe($TI, vload(Vec{$(2W),Int16}, meas, 2n + 1), sinv, cosv)
             early = shufflevector($(csym[1]), $(csym[2]), Val($emask))
             late = shufflevector($(csym[g+fl+1]), $(csym[g+fl+2]), Val($lmask))
-            cE = _wide32(early); cP = _wide32($(csym[g+1])); cL = _wide32(late)
-            IE, QE, IP, QP, IL, QL = _accum_epl(IE, QE, IP, QP, IL, QL, cE, cP, cL, DI, DQ)
+            acc = _acc(acc, early, $(csym[g+1]), late, DI, DQ)
             $(shift...)
             n += $W
         end
-        ((sum(IE), sum(QE)), (sum(IP), sum(QP)), (sum(IL), sum(QL)))
+        _acc_sum(acc)
     end
 end
 
@@ -297,22 +385,19 @@ end
 # ext[n+1] / ext[n+D+1] / ext[n+2D+1]. Generator is warm (continuing); timed region is 0-alloc.
 function correlate_epl_unfused!(ext::Vector{Int8}, csin::Vector{Int8}, ccos::Vector{Int8},
                                 meas::Vector{Int16}, code_gen, tbl, fs, freq, N::Int,
-                                ::Val{W}, ::Val{D}) where {W,D}
+                                ::Val{W}, ::Val{D}, ::Val{TI}) where {W,D,TI}
     gen_code!(view(ext, (D + 1):(D + N + D)), code_gen)     # samples 0 … N+D−1 (ext[1:D] stay 0)
     generate_carrier!(view(csin, 1:N), view(ccos, 1:N), tbl; frequency = freq, sampling_frequency = fs)
-    IE = zero(Vec{W,Int32}); QE = zero(Vec{W,Int32}); IP = zero(Vec{W,Int32})
-    QP = zero(Vec{W,Int32}); IL = zero(Vec{W,Int32}); QL = zero(Vec{W,Int32})
+    acc = _acc_zeros(TI, Val(W))
     n = 0
     @inbounds while n < length(csin)
-        DI, DQ = _wipe(vload(Vec{2W,Int16}, meas, 2n + 1),
+        DI, DQ = _wipe(TI, vload(Vec{2W,Int16}, meas, 2n + 1),
                        vload(Vec{W,Int8}, csin, n + 1), vload(Vec{W,Int8}, ccos, n + 1))
-        cE = _wide32(vload(Vec{W,Int8}, ext, n + 1))
-        cP = _wide32(vload(Vec{W,Int8}, ext, n + D + 1))
-        cL = _wide32(vload(Vec{W,Int8}, ext, n + 2D + 1))
-        IE, QE, IP, QP, IL, QL = _accum_epl(IE, QE, IP, QP, IL, QL, cE, cP, cL, DI, DQ)
+        acc = _acc(acc, vload(Vec{W,Int8}, ext, n + 1), vload(Vec{W,Int8}, ext, n + D + 1),
+                   vload(Vec{W,Int8}, ext, n + 2D + 1), DI, DQ)
         n += W
     end
-    ((sum(IE), sum(QE)), (sum(IP), sum(QP)), (sum(IL), sum(QL)))
+    _acc_sum(acc)
 end
 
 # ── HYBRID E/P/L: materialise ONLY the code (fast run-fill `gen_code!`, same `ext` layout as
@@ -322,22 +407,96 @@ end
 # instead of the unfused's three (code + sin + cos), while still getting run-fill's fast code
 # generation that the fully-fused path lacks. Arithmetic is bit-identical to both kernels.
 function correlate_epl_hybrid!(ext::Vector{Int8}, meas::Vector{Int16}, code_gen, reng, N::Int,
-                               ::Val{W}, ::Val{D}) where {W,D}
+                               ::Val{W}, ::Val{D}, ::Val{TI}) where {W,D,TI}
     gen_code!(view(ext, (D + 1):(D + N + D)), code_gen)     # samples 0 … N+D−1 (ext[1:D] stay 0)
-    IE = zero(Vec{W,Int32}); QE = zero(Vec{W,Int32}); IP = zero(Vec{W,Int32})
-    QP = zero(Vec{W,Int32}); IL = zero(Vec{W,Int32}); QL = zero(Vec{W,Int32})
+    acc = _acc_zeros(TI, Val(W))
     rs = carrier_state(reng, 0)
     n = 0; lim = length(meas) ÷ 2
     @inbounds while n < lim
         sinv, cosv = carrier_lookup(reng, rs); rs = carrier_advance(reng, rs, 1)
-        DI, DQ = _wipe(vload(Vec{2W,Int16}, meas, 2n + 1), sinv, cosv)
-        cE = _wide32(vload(Vec{W,Int8}, ext, n + 1))
-        cP = _wide32(vload(Vec{W,Int8}, ext, n + D + 1))
-        cL = _wide32(vload(Vec{W,Int8}, ext, n + 2D + 1))
-        IE, QE, IP, QP, IL, QL = _accum_epl(IE, QE, IP, QP, IL, QL, cE, cP, cL, DI, DQ)
+        DI, DQ = _wipe(TI, vload(Vec{2W,Int16}, meas, 2n + 1), sinv, cosv)
+        acc = _acc(acc, vload(Vec{W,Int8}, ext, n + 1), vload(Vec{W,Int8}, ext, n + D + 1),
+                   vload(Vec{W,Int8}, ext, n + 2D + 1), DI, DQ)
         n += W
     end
-    ((sum(IE), sum(QE)), (sum(IP), sum(QP)), (sum(IL), sum(QL)))
+    _acc_sum(acc)
+end
+
+# ── HYBRID-BLOCKED E/P/L: the hybrid's strategy taken to its conclusion — strip-mine the whole
+# correlation into BLK-sample blocks and regenerate BOTH the code and the carrier into SMALL,
+# L1-resident scratch that is REUSED across blocks. So, unlike the plain hybrid (which keeps a
+# full ≈N-sample code buffer per channel), this materialises NOTHING of length N: its working set
+# is just `3·BLK` scratch bytes per channel (code block + sin + cos), independent of N.
+#
+# Per block it runs two tight loops — fill (code via run-fill `gen_code!`, carrier via the value
+# engine in a 4-way-unrolled fill, both shuffle-port bound) then correlate (cheap `ext`/carrier
+# loads + the multiply-port-bound wipe + E/P/L accumulate) — so each loop hits peak port
+# utilisation the way the unfused's two full-length passes do, but without ever touching the LLC.
+# That combination is the point: it is fused-class in LLC footprint (so it keeps scaling with
+# cores once the working set spills, where even the plain hybrid's code buffer eventually loses to
+# the fused's zero-buffer kernel) yet hybrid-class in per-sample cost (cheap loads, not per-chunk
+# value-engine permutes). Arithmetic is bit-identical to all three other kernels.
+#
+# `extb` holds samples (b−D) … (b+len−1+D) for the current block at absolute start `b` in entries
+# 1 … len+2D (Early/Prompt/Late at output n read entries n+1 / n+D+1 / n+2D+1, as in the unfused).
+# The leading D entries of block 0 are the sample-<0 zero edge; every later block carries the
+# 2D-sample overlap from the previous block's tail (the run-fill generator is continuing, so the
+# code stays exact across the block seam). `BLK` is a multiple of `W`, so every block length is too.
+
+# Fill `len` carrier samples starting at absolute sample `start` into csb/ccb, 4-way unrolled so
+# the permute lookups pipeline (the same scheme `generate_carrier!` uses internally, but driven by
+# the value engine at an exact absolute start, so it is bit-identical to the fused carrier).
+@inline function _epl_fill_carrier!(csb::Vector{Int8}, ccb::Vector{Int8}, reng,
+                                    start::Int, len::Int, ::Val{W}) where {W}
+    s0 = carrier_state(reng, start);      s1 = carrier_state(reng, start + W)
+    s2 = carrier_state(reng, start + 2W); s3 = carrier_state(reng, start + 3W)
+    n = 0
+    @inbounds while n + 4W <= len
+        a0, b0 = carrier_lookup(reng, s0); a1, b1 = carrier_lookup(reng, s1)
+        a2, b2 = carrier_lookup(reng, s2); a3, b3 = carrier_lookup(reng, s3)
+        vstore(a0, csb, n + 1);      vstore(b0, ccb, n + 1)
+        vstore(a1, csb, n + W + 1);  vstore(b1, ccb, n + W + 1)
+        vstore(a2, csb, n + 2W + 1); vstore(b2, ccb, n + 2W + 1)
+        vstore(a3, csb, n + 3W + 1); vstore(b3, ccb, n + 3W + 1)
+        s0 = carrier_advance(reng, s0, 4); s1 = carrier_advance(reng, s1, 4)
+        s2 = carrier_advance(reng, s2, 4); s3 = carrier_advance(reng, s3, 4)
+        n += 4W
+    end
+    @inbounds while n < len                                  # < 4W tail, one chunk at a time
+        a0, b0 = carrier_lookup(reng, s0); vstore(a0, csb, n + 1); vstore(b0, ccb, n + 1)
+        s0 = carrier_advance(reng, s0, 1)
+        n += W
+    end
+    nothing
+end
+
+function correlate_epl_hybrid_blocked!(extb::Vector{Int8}, csb::Vector{Int8}, ccb::Vector{Int8},
+                                       meas::Vector{Int16}, code_gen, reng,
+                                       ::Val{W}, ::Val{D}, ::Val{BLK}, ::Val{TI}) where {W,D,BLK,TI}
+    acc = _acc_zeros(TI, Val(W))
+    lim = length(meas) ÷ 2
+    b = 0; prevlen = 0
+    @inbounds while b < lim
+        len = min(BLK, lim - b)
+        if prevlen == 0                                      # block 0: leading D zeros, fill 0…len+D−1
+            for i in 1:D; extb[i] = Int8(0); end
+            gen_code!(view(extb, (D + 1):(D + len + D)), code_gen)
+        else                                                 # carry 2D overlap from the prev tail, fill len
+            for i in 1:2D; extb[i] = extb[prevlen + i]; end
+            gen_code!(view(extb, (2D + 1):(2D + len)), code_gen)
+        end
+        _epl_fill_carrier!(csb, ccb, reng, b, len, Val(W))
+        n = 0
+        @inbounds while n < len
+            DI, DQ = _wipe(TI, vload(Vec{2W,Int16}, meas, 2(b + n) + 1),
+                           vload(Vec{W,Int8}, csb, n + 1), vload(Vec{W,Int8}, ccb, n + 1))
+            acc = _acc(acc, vload(Vec{W,Int8}, extb, n + 1), vload(Vec{W,Int8}, extb, n + D + 1),
+                       vload(Vec{W,Int8}, extb, n + 2D + 1), DI, DQ)
+            n += W
+        end
+        b += len; prevlen = len
+    end
+    _acc_sum(acc)
 end
 
 # Prompt code engine (a single stream — Early/Late are derived by lane-shift) + carrier engine.
@@ -359,39 +518,44 @@ if isdefined(GNSSSignals, :code_engine)
             freq = 1234.0                              # residual carrier / Doppler to wipe off (Hz)
             N = round(Int, fs * 1e-3)                  # 1 ms
             D = round(Int, 0.5 * fs / fc)              # ½-chip Early/Late spacing, in samples
-            carrier_amplitude = 8                      # carrier ∈ ±amplitude (stored Int8)
-            adc_bits = 12                              # measurement is a 12-bit ADC sample (Int16)
+            # Carrier amplitude + wipe type auto-chosen from the 12-bit ADC range (Int16 fast path).
             plan = GNSSSignals.CodeReplicaLUT(_GPSL1(), 1)
             code_gen = GNSSSignals.CodeGeneratorLUT(plan, fs, fc)   # warm generator for the unfused fill
-            tbl = SinCosTable(Int8; steps = 64, amplitude = carrier_amplitude)
+            tbl = SinCosTable(Int8; steps = 64, amplitude = _CARRIER_AMP)
             ceng1, reng = _epl_engines(plan, tbl, fs, fc, freq)
 
             # Zero-pad to a whole number of W-wide chunks (Npad samples). meas is complex with
             # re/im interleaved → 2·Npad Int16 words. ext spans samples −D … (Npad−1)+D.
             Npad = cld(N, _CORR_W) * _CORR_W
-            lim = Int16(1) << (adc_bits - 1)                       # 12-bit signed range ±2048
+            lim = Int16(_MAX_MEAS)                                  # 12-bit signed range ±2048
             meas = zeros(Int16, 2 * Npad)                          # [re₀, im₀, re₁, im₁, …]
             meas[1:2N] .= rand(-lim:(lim - Int16(1)), 2N)
             ext = zeros(Int8, Npad + 2D); csin = zeros(Int8, Npad); ccos = zeros(Int8, Npad)
+            # hybrid-blocked: small L1-resident scratch reused across blocks (size independent of N).
+            extb = zeros(Int8, _CORR_BLK + 2D); csb = zeros(Int8, _CORR_BLK); ccb = zeros(Int8, _CORR_BLK)
 
             g = SUITE["correlation"][label]
             g["fused"] = @benchmarkable correlate_epl_fused(
-                $meas, $ceng1, $reng, $(Val(_CORR_W)), $(Val(D)),
+                $meas, $ceng1, $reng, $(Val(_CORR_W)), $(Val(D)), $(Val(_WIPE_TI)),
             ) evals = 1 samples = 1000
             g["unfused"] = @benchmarkable correlate_epl_unfused!(
                 $ext, $csin, $ccos, $meas, $code_gen, $tbl, $fs, $freq, $N,
-                $(Val(_CORR_W)), $(Val(D)),
+                $(Val(_CORR_W)), $(Val(D)), $(Val(_WIPE_TI)),
             ) evals = 1 samples = 1000
             g["hybrid"] = @benchmarkable correlate_epl_hybrid!(
-                $ext, $meas, $code_gen, $reng, $N, $(Val(_CORR_W)), $(Val(D)),
+                $ext, $meas, $code_gen, $reng, $N, $(Val(_CORR_W)), $(Val(D)), $(Val(_WIPE_TI)),
+            ) evals = 1 samples = 1000
+            g["hybrid-blocked"] = @benchmarkable correlate_epl_hybrid_blocked!(
+                $extb, $csb, $ccb, $meas, $code_gen, $reng,
+                $(Val(_CORR_W)), $(Val(D)), $(Val(_CORR_BLK)), $(Val(_WIPE_TI)),
             ) evals = 1 samples = 1000
         end
     end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# PARALLEL multi-channel correlation — FUSED vs UNFUSED vs HYBRID across many satellites
-# (Polyester).
+# PARALLEL multi-channel correlation — FUSED vs UNFUSED vs HYBRID vs HYBRID-BLOCKED across many
+# satellites (Polyester).
 #
 # This is where the fused/unfused trade-off INVERTS. Per channel (single thread) the fused is
 # execution-port bound and ~10% slower than the unfused (see the single-channel rows above).
@@ -403,15 +567,24 @@ end
 # memory bandwidth: the unfused stops scaling with cores while the fused keeps scaling, because
 # it never touches the bus. So the fused WINS once the working set exceeds the LLC.
 #
-# The HYBRID is the best of both: it materialises only the CODE (the fast run-fill `gen_code!`
-# the fully-fused path can't use) and keeps the carrier in-register, so it touches ONE buffer
-# per channel (≈ N Int8) instead of three. It beats fused everywhere (cheap `ext` loads replace
-# the per-chunk value-engine permute + DDA) and, once the working set spills the LLC, also beats
-# unfused (a third of the bandwidth). Measured (40 MHz, 10 ch, 24 threads, 12-core / 24 MB-L3):
-# at 20 ms it is ~0.88× fused and ~0.67× unfused; at 30 ms ~0.94× fused and ~0.47× unfused —
-# the fastest of the three. At 5 ms (fits L3) the unfused still wins single-buffer-bandwidth and
-# the hybrid is second. So: unfused for cache-resident work, hybrid once it spills, fused only
-# when zero per-channel scratch is required.
+# The HYBRID is the best of those two: it materialises only the CODE (the fast run-fill
+# `gen_code!` the fully-fused path can't use) and keeps the carrier in-register, so it touches ONE
+# buffer per channel (≈ N Int8) instead of three. It beats fused at moderate channel counts (cheap
+# `ext` loads replace the per-chunk value-engine permute + DDA) and, once the working set spills
+# the LLC, also beats unfused (a third of the bandwidth). But its per-channel ≈ N code buffer is
+# still O(N): push to many channels / long integration (24 ch, 30 ms) and it too spills hard and
+# falls BEHIND the zero-buffer fused (measured ~1.25× fused there).
+#
+# The HYBRID-BLOCKED removes that last buffer: it strip-mines into BLK-sample blocks and
+# regenerates BOTH code and carrier into small L1-resident scratch reused across blocks, so its
+# working set is O(BLK), not O(N) — fused-class LLC footprint with hybrid-class per-sample cost
+# (see the kernel comment above). Measured (40 MHz, 24 threads, Zen5 / AVX-512), it is the fastest
+# kernel in every spilling regime: 10 ch 20 ms ~0.85× fused / ~0.69× unfused; 24 ch 20 ms ~0.83×
+# fused / ~0.81× hybrid; 24 ch 30 ms ~0.82× fused / ~0.65× hybrid. It also beats fused and hybrid
+# when cache-resident (10 ch 5 ms ~0.87× fused / ~0.97× hybrid); the ONLY regime it does not win
+# is pure cache-resident vs the unfused (~1.04×), where both do identical work and the unfused's
+# two full-length passes are the ceiling. So: hybrid-blocked is the all-round pick, with the
+# unfused still marginally ahead only when everything fits in cache.
 #
 # The crossover is governed by working-set vs LLC size, and the effect only appears with
 # `Threads.nthreads() > 1` (run julia with `-t auto` / `JULIA_NUM_THREADS`). Two representative
@@ -419,10 +592,11 @@ end
 # sample rates / fewer channels the working set is smaller, so the crossover moves to longer
 # integration.
 #
-# Each channel gets its own PRN, Doppler, code/carrier engines and (unfused/hybrid) scratch
-# buffers; the measurement is shared. State is bundled in `_EPLChannels` so Polyester sees only
-# a struct and the loop index — it does NOT rewrite the per-channel vectors into stride-arrays
-# (which would not match the kernels' `Vector` signatures). One channel per `@batch` task.
+# Each channel gets its own PRN, Doppler, code/carrier engines and (unfused / hybrid /
+# hybrid-blocked) scratch buffers; the measurement is shared. State is bundled in `_EPLChannels`
+# so Polyester sees only a struct and the loop index — it does NOT rewrite the per-channel
+# vectors into stride-arrays (which would not match the kernels' `Vector` signatures). One
+# channel per `@batch` task.
 # ─────────────────────────────────────────────────────────────────────────────
 # Defined unconditionally (a struct must be top level); the drivers/registration that use
 # Polyester's `@batch` are guarded below.
@@ -434,6 +608,10 @@ struct _EPLChannels{W,D,CE,RE,CG,TB}
     extsH::Vector{Vector{Int8}}   # hybrid's own code buffer (so it never aliases the unfused's)
     csins::Vector{Vector{Int8}}
     ccoss::Vector{Vector{Int8}}
+    # hybrid-blocked's per-channel L1 scratch (block code + sin + cos), size independent of N
+    extbs::Vector{Vector{Int8}}
+    csbs::Vector{Vector{Int8}}
+    ccbs::Vector{Vector{Int8}}
     code_gens::Vector{CG}
     tbls::Vector{TB}
     fs::Float64
@@ -449,12 +627,12 @@ if _HAS_POLYESTER && isdefined(GNSSSignals, :code_engine)
         N = round(Int, fs * 1e-3 * ms)
         D = round(Int, 0.5 * fs / fc)
         Npad = cld(N, W) * W
-        lim = Int16(1) << 11                                   # 12-bit ADC
+        lim = Int16(_MAX_MEAS)                                 # 12-bit ADC ±2048
         meas = zeros(Int16, 2 * Npad)
         meas[1:2N] .= rand(-lim:(lim - Int16(1)), 2N)
         plans = [GNSSSignals.CodeReplicaLUT(_GPSL1(), prn) for prn in 1:nch]
         freqs = [1234.0 + 137.0 * (s - 1) for s in 1:nch]      # spread the residual Dopplers
-        tbls = [SinCosTable(Int8; steps = 64, amplitude = 8) for _ in 1:nch]
+        tbls = [SinCosTable(Int8; steps = 64, amplitude = _CARRIER_AMP) for _ in 1:nch]
         engs = [_epl_engines(plans[s], tbls[s], fs, fc, freqs[s]) for s in 1:nch]
         cengs = [e[1] for e in engs]
         rengs = [e[2] for e in engs]
@@ -463,28 +641,37 @@ if _HAS_POLYESTER && isdefined(GNSSSignals, :code_engine)
         extsH = [zeros(Int8, Npad + 2D) for _ in 1:nch]
         csins = [zeros(Int8, Npad) for _ in 1:nch]
         ccoss = [zeros(Int8, Npad) for _ in 1:nch]
+        extbs = [zeros(Int8, _CORR_BLK + 2D) for _ in 1:nch]
+        csbs = [zeros(Int8, _CORR_BLK) for _ in 1:nch]
+        ccbs = [zeros(Int8, _CORR_BLK) for _ in 1:nch]
         ch = _EPLChannels{W,D,eltype(cengs),eltype(rengs),eltype(code_gens),eltype(tbls)}(
-            meas, cengs, rengs, exts, extsH, csins, ccoss, code_gens, tbls, Float64(fs), freqs, N,
-            zeros(Int, nch))
+            meas, cengs, rengs, exts, extsH, csins, ccoss, extbs, csbs, ccbs,
+            code_gens, tbls, Float64(fs), freqs, N, zeros(Int, nch))
         ch
     end
 
     # One channel of work (indexing lives here, not in the `@batch` body, so Polyester leaves
     # the per-channel vectors as plain `Vector`s).
     @inline function _epl_one_fused!(ch::_EPLChannels{W,D}, s) where {W,D}
-        @inbounds r = correlate_epl_fused(ch.meas, ch.cengs[s], ch.rengs[s], Val(W), Val(D))
+        @inbounds r = correlate_epl_fused(ch.meas, ch.cengs[s], ch.rengs[s], Val(W), Val(D), Val(_WIPE_TI))
         @inbounds ch.out[s] = r[2][1]
         nothing
     end
     @inline function _epl_one_unfused!(ch::_EPLChannels{W,D}, s) where {W,D}
         @inbounds r = correlate_epl_unfused!(ch.exts[s], ch.csins[s], ch.ccoss[s], ch.meas,
-            ch.code_gens[s], ch.tbls[s], ch.fs, ch.freqs[s], ch.N, Val(W), Val(D))
+            ch.code_gens[s], ch.tbls[s], ch.fs, ch.freqs[s], ch.N, Val(W), Val(D), Val(_WIPE_TI))
         @inbounds ch.out[s] = r[2][1]
         nothing
     end
     @inline function _epl_one_hybrid!(ch::_EPLChannels{W,D}, s) where {W,D}
         @inbounds r = correlate_epl_hybrid!(ch.extsH[s], ch.meas, ch.code_gens[s], ch.rengs[s],
-            ch.N, Val(W), Val(D))
+            ch.N, Val(W), Val(D), Val(_WIPE_TI))
+        @inbounds ch.out[s] = r[2][1]
+        nothing
+    end
+    @inline function _epl_one_hybrid_blocked!(ch::_EPLChannels{W,D}, s) where {W,D}
+        @inbounds r = correlate_epl_hybrid_blocked!(ch.extbs[s], ch.csbs[s], ch.ccbs[s], ch.meas,
+            ch.code_gens[s], ch.rengs[s], Val(W), Val(D), Val(_CORR_BLK), Val(_WIPE_TI))
         @inbounds ch.out[s] = r[2][1]
         nothing
     end
@@ -494,6 +681,8 @@ if _HAS_POLYESTER && isdefined(GNSSSignals, :code_engine)
         (Polyester.@batch for s in eachindex(ch.cengs); _epl_one_unfused!(ch, s); end; ch.out)
     _epl_hybrid_par!(ch::_EPLChannels) =
         (Polyester.@batch for s in eachindex(ch.cengs); _epl_one_hybrid!(ch, s); end; ch.out)
+    _epl_hybrid_blocked_par!(ch::_EPLChannels) =
+        (Polyester.@batch for s in eachindex(ch.cengs); _epl_one_hybrid_blocked!(ch, s); end; ch.out)
 
     let nch = 10, fs = 40e6, fc = 1.023e6
         for ms in (5, 20)                              # 5 ms: fits L3; 20 ms: spills L3 (see note)
@@ -502,6 +691,7 @@ if _HAS_POLYESTER && isdefined(GNSSSignals, :code_engine)
             g["fused"]   = @benchmarkable _epl_fused_par!($ch) evals = 1 samples = 200
             g["unfused"] = @benchmarkable _epl_unfused_par!($ch) evals = 1 samples = 200
             g["hybrid"]  = @benchmarkable _epl_hybrid_par!($ch) evals = 1 samples = 200
+            g["hybrid-blocked"] = @benchmarkable _epl_hybrid_blocked_par!($ch) evals = 1 samples = 200
         end
     end
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -192,13 +192,15 @@ end
 # independent correlations. The wipe is a per-sample complex multiply: deinterleave mᵣ/mᵢ and
 # multiply by the carrier. The arithmetic width is chosen at compile time (see `choose_carrier`):
 #   • Int16 fast path — when 2·max|meas|·amplitude ≤ typemax(Int16) (true for the 12-bit ADC at the
-#     auto-chosen amplitude), DI/DQ stay Int16 (`vpmullw`, half the AVX register width). The code
-#     step Σ codeₓ·DI is then a `vpmaddwd` (Int16×Int16→Int32 pairwise-add) — a dot-product reduction
-#     into half-width accumulators. NOTE: `vpmaddwd` pays off for the *reduced-sum* code step, but
-#     NOT for the per-sample wipe (its tiling shuffles + 4× carrier bandwidth lose there — measured);
-#     so the wipe stays a straight deinterleave-multiply. Net ~2× on AVX-512, ~1.2× on AVX2.
+#     auto-chosen amplitude), DI/DQ stay Int16 (`vpmullw`, half the SIMD register width). The code
+#     step Σ codeₓ·DI is then a fused widening multiply-add: `vpmaddwd` (Int16×Int16→Int32 pairwise)
+#     into half-width accumulators on AVX2/AVX-512, or `SMLAL`/`vmlal` (per-lane widening MAC) into
+#     full-width accumulators on NEON. NOTE: this fused MAC pays off for the *reduced-sum* code step,
+#     but NOT for the per-sample wipe (`vpmaddwd`'s tiling shuffles + 4× carrier bandwidth lose there
+#     — measured); so the wipe stays a straight deinterleave-multiply. Net ~2× on AVX-512, ~1.2× on
+#     AVX2; NEON expected to gain from the narrower wipe + SMLAL (verified on the macos-14 runner).
 #   • Int32 fallback — exact for any amplitude (per-sample products can reach 2048·127·2 > Int16), and
-#     the only path on NEON/portable (no `vpmaddwd`). Deinterleave, widen to Int32, `vpmulld`.
+#     the only path on the scalar `Portable` backend. Deinterleave, widen to Int32, `vpmulld`.
 # Both paths are bit-identical (the Int16 path provably cannot overflow when selected). The
 # amplitude is auto-maximised within the Int16-safe bound, so a coarser ADC keeps a finer carrier.
 #
@@ -243,20 +245,23 @@ const _CORR_BLK = 8192
 
 # ── Int16 carrier-wipe fast path ────────────────────────────────────────────
 # The shared wipe DI = mᵣ·cos + mᵢ·sin / DQ = mᵢ·cos − mᵣ·sin is the dominant per-sample cost.
-# It can run entirely in Int16 (half the AVX register width of the Int32 form — and feeding a
-# `vpmaddwd` code accumulate) *iff* it cannot overflow: |DI| ≤ 2·max|meas|·amplitude ≤ typemax(Int16).
-# `vpmaddwd` exists on AVX2/AVX-512 only, so the fast path is gated on the backend too.
-const _HAS_MADDWD = _CORR_W in (32, 64)        # AVX2 (W=32) / AVX-512 (W=64)
+# It can run entirely in Int16 (half the SIMD register width of the Int32 form) *iff* it cannot
+# overflow: |DI| ≤ 2·max|meas|·amplitude ≤ typemax(Int16). The code accumulate Σ codeₓ·DI then uses
+# a fused widening multiply-add: `vpmaddwd` on AVX2/AVX-512 (pairwise, half-width accumulators) or
+# `SMLAL`/`vmlal` on AArch64 NEON (per-lane widening MAC, full-width accumulators — emitted by LLVM
+# from the widening pattern). So the fast path runs on any SIMD backend (W>1); only the truly scalar
+# `Portable` (W=1) backend forgoes it.
+const _HAS_INT16 = _CORR_W in (16, 32, 64)     # NEON (W=16) / AVX2 (W=32) / AVX-512 (W=64)
 
 # Pick (carrier amplitude, wipe intermediate type) for a declared maximum |measurement component|.
 # REQUIRED input, NO default: under-declaring `max_meas` would silently overflow the Int16 wipe and
 # corrupt results, while over-declaring only forgoes the speedup. We take the LARGEST Int16-safe
 # amplitude (carrier rounding error is ±0.5 regardless of amplitude, so relative error ≈ 0.5/amp —
 # bigger amp = finer carrier), capped at the Int8 storage limit. If no amplitude ≥1 is safe (very
-# large `max_meas`) or the backend lacks `vpmaddwd`, fall back to the exact Int32 wipe at full Int8
+# large `max_meas`) or the backend is scalar, fall back to the exact Int32 wipe at full Int8
 # amplitude (Int32 has the headroom, so best fidelity there).
 function choose_carrier(max_meas::Integer)
-    _HAS_MADDWD || return (Int(typemax(Int8)), Int32)
+    _HAS_INT16 || return (Int(typemax(Int8)), Int32)
     a = Int(typemax(Int16)) ÷ (2 * Int(max_meas))           # ⌊32767 / (2·max_meas)⌋, may be 0
     a >= 1 ? (min(a, Int(typemax(Int8))), Int16) : (Int(typemax(Int8)), Int32)
 end
@@ -327,16 +332,26 @@ end
 end
 
 # Six E/P/L accumulators as a tuple (IE,QE,IP,QP,IL,QL); `_acc_zeros`/`_acc_sum` bracket the loop
-# and `_acc` folds one chunk. The accumulate dispatches on the DI/DQ element type the wipe produced:
-#   Int32 DI → widen code to Int32, vpmulld into full-width (Vec{W,Int32}) accumulators.
-#   Int16 DI → widen code to Int16, vpmaddwd into half-width (Vec{W÷2,Int32}) accumulators.
+# and `_acc` folds one chunk. The accumulate dispatches on the DI/DQ element type the wipe produced,
+# and (for the Int16 path) on the backend width:
+#   Int32 DI                → widen code to Int32, vpmulld into full-width (Vec{W,Int32}) accumulators.
+#   Int16 DI, W∈{32,64} AVX  → vpmaddwd (pairwise) into HALF-width (Vec{W÷2,Int32}) accumulators.
+#   Int16 DI, W=16   NEON    → per-lane widening MAC → SMLAL, into FULL-width (Vec{16,Int32}) accs.
 @inline _acc_zeros(::Type{Int32}, ::Val{W}) where {W} = ntuple(_ -> zero(Vec{W,Int32}), Val(6))
-@inline _acc_zeros(::Type{Int16}, ::Val{W}) where {W} = ntuple(_ -> zero(Vec{W ÷ 2,Int32}), Val(6))
+@inline _acc_zeros(::Type{Int16}, ::Val{16}) = ntuple(_ -> zero(Vec{16,Int32}), Val(6))      # NEON: per-lane
+@inline _acc_zeros(::Type{Int16}, ::Val{W}) where {W} = ntuple(_ -> zero(Vec{W ÷ 2,Int32}), Val(6))  # AVX: pairwise
 @inline _acc_sum(a) = ((sum(a[1]), sum(a[2])), (sum(a[3]), sum(a[4])), (sum(a[5]), sum(a[6])))
 @inline function _acc(a, cE::Vec{W,Int8}, cP::Vec{W,Int8}, cL::Vec{W,Int8}, DI::Vec{W,Int32}, DQ::Vec{W,Int32}) where {W}
     e = _wide32(cE); p = _wide32(cP); l = _wide32(cL)
     (a[1] + e * DI, a[2] + e * DQ, a[3] + p * DI, a[4] + p * DQ, a[5] + l * DI, a[6] + l * DQ)
 end
+# NEON Int16 path (W=16): widen code & DI to Int32 from Int16 so LLVM emits SMLAL (sext-i16 operands).
+@inline function _acc(a, cE::Vec{16,Int8}, cP::Vec{16,Int8}, cL::Vec{16,Int8}, DI::Vec{16,Int16}, DQ::Vec{16,Int16})
+    e = _wide32(_wide16(cE)); p = _wide32(_wide16(cP)); l = _wide32(_wide16(cL))
+    di = _wide32(DI); dq = _wide32(DQ)
+    (a[1] + e * di, a[2] + e * dq, a[3] + p * di, a[4] + p * dq, a[5] + l * di, a[6] + l * dq)
+end
+# AVX Int16 path (W∈{32,64}): vpmaddwd pairwise into half-width accumulators.
 @inline function _acc(a, cE::Vec{W,Int8}, cP::Vec{W,Int8}, cL::Vec{W,Int8}, DI::Vec{W,Int16}, DQ::Vec{W,Int16}) where {W}
     e = _wide16(cE); p = _wide16(cP); l = _wide16(cL)
     (a[1] + _maddacc(e, DI), a[2] + _maddacc(e, DQ), a[3] + _maddacc(p, DI),

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -144,9 +144,11 @@ end
 # the level is labelled as a multiplier (2x = sample twice per chip). Grouped by signal /
 # oversampling / size under `code/oversampling sweep/…` so "original" and "LUT" sit
 # adjacent. Same N + fs/fc for both, and the LUT side uses the warm generator (0-alloc),
-# matching the original's 0-alloc fill. The LUT is ~flat in the oversampling ratio (one
-# permute/sample); the original's run-fill speeds up as it grows — so the LUT wins most at
-# low oversampling and the original catches up high (crossover ~8-16x BPSK, later BOC).
+# matching the original's 0-alloc fill. The LUT uses the windowed permute (flat in the
+# oversampling ratio) at low oversampling and switches to a broadcast run-fill once the
+# baked table is oversampled ≳8× (AVX-512) / ≳4× (AVX2), so it tracks the original's
+# run-fill speed-up at high oversampling instead of staying flat. It still wins outright at
+# low oversampling and for modulated signals (baked subcarrier).
 # Two representative signals (BPSK + BOC(1,1)); both at fc = 1.023 MHz.
 const _SWEEP_SIGS = let s = Any[("GPSL1CA", _GPSL1(), 1, 1)]   # (name, signal, prn, subchip_factor P)
     isdefined(GNSSSignals, :GalileoE1B_BOC11) &&

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -315,6 +315,31 @@ function correlate_epl_unfused!(ext::Vector{Int8}, csin::Vector{Int8}, ccos::Vec
     ((sum(IE), sum(QE)), (sum(IP), sum(QP)), (sum(IL), sum(QL)))
 end
 
+# ── HYBRID E/P/L: materialise ONLY the code (fast run-fill `gen_code!`, same `ext` layout as
+# unfused), but keep the CARRIER in-register via the value-based engine and FUSE the wipe +
+# E/P/L accumulate. Code is read at Early/Prompt/Late offsets from `ext` (cheap loads); the
+# carrier never touches memory. So this writes/reads ONE scratch buffer per channel (≈ N Int8)
+# instead of the unfused's three (code + sin + cos), while still getting run-fill's fast code
+# generation that the fully-fused path lacks. Arithmetic is bit-identical to both kernels.
+function correlate_epl_hybrid!(ext::Vector{Int8}, meas::Vector{Int16}, code_gen, reng, N::Int,
+                               ::Val{W}, ::Val{D}) where {W,D}
+    gen_code!(view(ext, (D + 1):(D + N + D)), code_gen)     # samples 0 … N+D−1 (ext[1:D] stay 0)
+    IE = zero(Vec{W,Int32}); QE = zero(Vec{W,Int32}); IP = zero(Vec{W,Int32})
+    QP = zero(Vec{W,Int32}); IL = zero(Vec{W,Int32}); QL = zero(Vec{W,Int32})
+    rs = carrier_state(reng, 0)
+    n = 0; lim = length(meas) ÷ 2
+    @inbounds while n < lim
+        sinv, cosv = carrier_lookup(reng, rs); rs = carrier_advance(reng, rs, 1)
+        DI, DQ = _wipe(vload(Vec{2W,Int16}, meas, 2n + 1), sinv, cosv)
+        cE = _wide32(vload(Vec{W,Int8}, ext, n + 1))
+        cP = _wide32(vload(Vec{W,Int8}, ext, n + D + 1))
+        cL = _wide32(vload(Vec{W,Int8}, ext, n + 2D + 1))
+        IE, QE, IP, QP, IL, QL = _accum_epl(IE, QE, IP, QP, IL, QL, cE, cP, cL, DI, DQ)
+        n += W
+    end
+    ((sum(IE), sum(QE)), (sum(IP), sum(QP)), (sum(IL), sum(QL)))
+end
+
 # Prompt code engine (a single stream — Early/Late are derived by lane-shift) + carrier engine.
 # Built once and reused. `code_engine`'s parameterless `default_backend()` const-folds to the
 # host backend, so the engine types are concrete and the fused kernel stays 0-alloc.
@@ -357,12 +382,16 @@ if isdefined(GNSSSignals, :code_engine)
                 $ext, $csin, $ccos, $meas, $code_gen, $tbl, $fs, $freq, $N,
                 $(Val(_CORR_W)), $(Val(D)),
             ) evals = 1 samples = 1000
+            g["hybrid"] = @benchmarkable correlate_epl_hybrid!(
+                $ext, $meas, $code_gen, $reng, $N, $(Val(_CORR_W)), $(Val(D)),
+            ) evals = 1 samples = 1000
         end
     end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# PARALLEL multi-channel correlation — FUSED vs UNFUSED across many satellites (Polyester).
+# PARALLEL multi-channel correlation — FUSED vs UNFUSED vs HYBRID across many satellites
+# (Polyester).
 #
 # This is where the fused/unfused trade-off INVERTS. Per channel (single thread) the fused is
 # execution-port bound and ~10% slower than the unfused (see the single-channel rows above).
@@ -374,17 +403,26 @@ end
 # memory bandwidth: the unfused stops scaling with cores while the fused keeps scaling, because
 # it never touches the bus. So the fused WINS once the working set exceeds the LLC.
 #
-# The crossover is therefore governed by `n_channels · 3 · N_samples` vs the LLC size, and the
-# effect only appears with `Threads.nthreads() > 1` (run julia with `-t auto` /
-# `JULIA_NUM_THREADS`). Two representative points at 40 MHz, 10 channels, on a 12-core / 24 MB-L3
-# machine: 5 ms (≈6 MB, fits L3 → fused still ~10% behind) and 20 ms (≈24 MB, spills L3 → fused
-# ~1.2× faster; +47% at 30 ms). At lower sample rates / fewer channels the working set is
-# smaller, so the crossover moves to longer integration.
+# The HYBRID is the best of both: it materialises only the CODE (the fast run-fill `gen_code!`
+# the fully-fused path can't use) and keeps the carrier in-register, so it touches ONE buffer
+# per channel (≈ N Int8) instead of three. It beats fused everywhere (cheap `ext` loads replace
+# the per-chunk value-engine permute + DDA) and, once the working set spills the LLC, also beats
+# unfused (a third of the bandwidth). Measured (40 MHz, 10 ch, 24 threads, 12-core / 24 MB-L3):
+# at 20 ms it is ~0.88× fused and ~0.67× unfused; at 30 ms ~0.94× fused and ~0.47× unfused —
+# the fastest of the three. At 5 ms (fits L3) the unfused still wins single-buffer-bandwidth and
+# the hybrid is second. So: unfused for cache-resident work, hybrid once it spills, fused only
+# when zero per-channel scratch is required.
 #
-# Each channel gets its own PRN, Doppler, code/carrier engines and (unfused) scratch buffers;
-# the measurement is shared. State is bundled in `_EPLChannels` so Polyester sees only a struct
-# and the loop index — it does NOT rewrite the per-channel vectors into stride-arrays (which
-# would not match the kernels' `Vector` signatures). One channel per `@batch` task.
+# The crossover is governed by working-set vs LLC size, and the effect only appears with
+# `Threads.nthreads() > 1` (run julia with `-t auto` / `JULIA_NUM_THREADS`). Two representative
+# points at 40 MHz, 10 channels: 5 ms (≈6 MB, fits L3) and 20 ms (≈24 MB, spills L3). At lower
+# sample rates / fewer channels the working set is smaller, so the crossover moves to longer
+# integration.
+#
+# Each channel gets its own PRN, Doppler, code/carrier engines and (unfused/hybrid) scratch
+# buffers; the measurement is shared. State is bundled in `_EPLChannels` so Polyester sees only
+# a struct and the loop index — it does NOT rewrite the per-channel vectors into stride-arrays
+# (which would not match the kernels' `Vector` signatures). One channel per `@batch` task.
 # ─────────────────────────────────────────────────────────────────────────────
 # Defined unconditionally (a struct must be top level); the drivers/registration that use
 # Polyester's `@batch` are guarded below.
@@ -393,6 +431,7 @@ struct _EPLChannels{W,D,CE,RE,CG,TB}
     cengs::Vector{CE}
     rengs::Vector{RE}
     exts::Vector{Vector{Int8}}
+    extsH::Vector{Vector{Int8}}   # hybrid's own code buffer (so it never aliases the unfused's)
     csins::Vector{Vector{Int8}}
     ccoss::Vector{Vector{Int8}}
     code_gens::Vector{CG}
@@ -421,10 +460,11 @@ if _HAS_POLYESTER && isdefined(GNSSSignals, :code_engine)
         rengs = [e[2] for e in engs]
         code_gens = [GNSSSignals.CodeGeneratorLUT(plans[s], fs, fc) for s in 1:nch]
         exts = [zeros(Int8, Npad + 2D) for _ in 1:nch]
+        extsH = [zeros(Int8, Npad + 2D) for _ in 1:nch]
         csins = [zeros(Int8, Npad) for _ in 1:nch]
         ccoss = [zeros(Int8, Npad) for _ in 1:nch]
         ch = _EPLChannels{W,D,eltype(cengs),eltype(rengs),eltype(code_gens),eltype(tbls)}(
-            meas, cengs, rengs, exts, csins, ccoss, code_gens, tbls, Float64(fs), freqs, N,
+            meas, cengs, rengs, exts, extsH, csins, ccoss, code_gens, tbls, Float64(fs), freqs, N,
             zeros(Int, nch))
         ch
     end
@@ -442,10 +482,18 @@ if _HAS_POLYESTER && isdefined(GNSSSignals, :code_engine)
         @inbounds ch.out[s] = r[2][1]
         nothing
     end
+    @inline function _epl_one_hybrid!(ch::_EPLChannels{W,D}, s) where {W,D}
+        @inbounds r = correlate_epl_hybrid!(ch.extsH[s], ch.meas, ch.code_gens[s], ch.rengs[s],
+            ch.N, Val(W), Val(D))
+        @inbounds ch.out[s] = r[2][1]
+        nothing
+    end
     _epl_fused_par!(ch::_EPLChannels) =
         (Polyester.@batch for s in eachindex(ch.cengs); _epl_one_fused!(ch, s); end; ch.out)
     _epl_unfused_par!(ch::_EPLChannels) =
         (Polyester.@batch for s in eachindex(ch.cengs); _epl_one_unfused!(ch, s); end; ch.out)
+    _epl_hybrid_par!(ch::_EPLChannels) =
+        (Polyester.@batch for s in eachindex(ch.cengs); _epl_one_hybrid!(ch, s); end; ch.out)
 
     let nch = 10, fs = 40e6, fc = 1.023e6
         for ms in (5, 20)                              # 5 ms: fits L3; 20 ms: spills L3 (see note)
@@ -453,6 +501,7 @@ if _HAS_POLYESTER && isdefined(GNSSSignals, :code_engine)
             g = SUITE["correlation"]["GPSL1CA E/P/L 40MHz $(nch)ch $(ms)ms ‖"]
             g["fused"]   = @benchmarkable _epl_fused_par!($ch) evals = 1 samples = 200
             g["unfused"] = @benchmarkable _epl_unfused_par!($ch) evals = 1 samples = 200
+            g["hybrid"]  = @benchmarkable _epl_hybrid_par!($ch) evals = 1 samples = 200
         end
     end
 end

--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -10,9 +10,11 @@
 #
 # The LUT resampler bakes the BOC/TMBOC subcarrier (and short secondary codes)
 # into an expanded ±1 Int8 table and resamples it with a single AVX-512 `vpermb`
-# / AVX2 `vpshufb` sliding-window permute over a drift-free integer DDA. It is
-# Int8/±1 only (no CBOC / cosine-BOC) and requires sub-chip oversampling
-# (`sampling_frequency ≥ code_frequency · subchip_factor`).
+# / AVX2 `vpshufb` sliding-window permute over a drift-free integer DDA — or, once the
+# baked table is heavily oversampled (so consecutive samples repeat a chip), a broadcast
+# run-fill that matches the original `gen_code!`'s store-bound speed instead of paying a
+# permute per window. It is Int8/±1 only (no CBOC / cosine-BOC) and requires sub-chip
+# oversampling (`sampling_frequency ≥ code_frequency · subchip_factor`).
 # ─────────────────────────────────────────────────────────────────────────────
 
 # `GNSSSignals.CodeLUT` — internal submodule vendoring the GNSSSignalsLUT.jl SIMD code
@@ -158,6 +160,13 @@ frequency, so a single plan serves any rate.
   contribution are rounded to the nearest *primary* chip; the fractional
   sub-chip residual is dropped (up to ~1 sub-chip vs the plain `gen_code!`).
   `start_phase = 0.0, start_index_shift = 0` gives `phase = 0` exactly.
+- **High-oversampling run-fill is approximate to ≤ a couple of samples.** Above
+  ~8× sub-chip oversampling the resampler broadcast-fills runs of identical chips
+  (matching the original `gen_code!`'s speed there) using a fixed-point samples-
+  per-chip DDA. Its chip boundaries are exact for any single fill and drift at
+  most a couple of samples only over a *very* long continued stream (~10⁶ chips) —
+  the same order as the permute path's own rate-quantisation drift, and well
+  inside the integer-chip-phase rounding above.
 """
 struct CodeReplicaLUT{S<:AbstractGNSSSignal}
     signal::S

--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -240,8 +240,37 @@ end
     (ph, r)
 end
 
+# ---- continuing run-fill generator (high-oversampling fast path) ----
+# The continuing counterpart of `_generate_runfill!`: at high oversampling broadcast-fills
+# runs of identical baked chips (store-bandwidth bound) instead of one permute per W samples.
+# Effectively byte-identical to the permute engines (the approximate samples-per-chip DDA in
+# `_runfill_core!` matches the exact `floor(step_num·n/2^_B)` boundaries for any single fill,
+# drifting ≤ a couple of samples only over ~10⁵ continued chips). State carried across fills
+# is `(c, acc, pos)`: the table chip index, the chip-start fractional phase `acc`, and `pos`
+# = samples of the current chip already emitted (so a fill may resume mid-run).
+mutable struct CodeGeneratorRunFill
+    const chips::Vector{Int8}
+    const L::Int
+    const ff::Int             # samples-per-chip in _RUNFILL_FP fixed point
+    const ni::Int             # padded fixed inner-store count
+    c::Int                    # current table chip index
+    acc::Int                  # chip-start fractional phase (delta & mask)
+    pos::Int                  # samples of the current chip already emitted
+end
+
+function CodeGeneratorRunFill(table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int)
+    CodeGeneratorRunFill(table.chips, table.length, _runfill_freqfix(step_num),
+                         _runfill_ni(step_num),
+                         mod(phase_offset, table.length), _RUNFILL_MASK, 0)
+end
+
+function fill_continue!(out::AbstractVector{<:Integer}, g::CodeGeneratorRunFill)
+    g.c, g.acc, g.pos = _runfill_dispatch!(out, g.chips, g.L, g.ff, g.ni, g.c, g.acc, g.pos)
+    out
+end
+
 # Portable (W=1): degenerate phase generator. Window emit + advance are scalar but correct.
-const CodeGeneratorAny = Union{CodeGenerator512,CodeGeneratorPhase}
+const CodeGeneratorAny = Union{CodeGenerator512,CodeGeneratorPhase,CodeGeneratorRunFill}
 
 # ---- factory: build the right backend generator from a step ratio + phase ----
 function make_generator(table::CodeTable, step_num::Integer, step_den::Integer;
@@ -251,7 +280,12 @@ function make_generator(table::CodeTable, step_num::Integer, step_den::Integer;
     (0 < step_num ≤ step_den) ||
         throw(ArgumentError("need 0 < step_numerator ≤ step_denominator (must oversample)"))
     sn = Int(step_num); sd = Int(step_den); ph = Int(phase)
-    if backend isa AVX512
+    if _use_runfill(sn, sd, backend)
+        # High oversampling: broadcast-fill runs (see `_generate_runfill!`) instead of paying
+        # a permute per window. Same windowed-length requirement as the AVX2/NEON permute.
+        backend isa Union{AVX2,Neon} && _check_windowed_length(table, backend)
+        CodeGeneratorRunFill(table, sn, sd, ph)
+    elseif backend isa AVX512
         CodeGenerator512(table, sn, sd, ph)
     elseif backend isa Union{AVX2,Neon}
         _check_windowed_length(table, backend)

--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -248,24 +248,32 @@ end
 # drifting ≤ a couple of samples only over ~10⁵ continued chips). State carried across fills
 # is `(c, acc, pos)`: the table chip index, the chip-start fractional phase `acc`, and `pos`
 # = samples of the current chip already emitted (so a fill may resume mid-run).
-mutable struct CodeGeneratorRunFill
+#
+# `NI` (the padded fixed inner-store count) is a *type* parameter so `fill_continue!` calls
+# the `Val{NI}`-specialised kernel statically — a runtime `Val(ni)` would box and allocate
+# every call, breaking the 0-alloc steady-state guarantee. `NI == 0` is the sentinel for the
+# generic (`ni > _RUNFILL_MAX_NI`) kernel, whose runtime count lives in the `ni` field.
+mutable struct CodeGeneratorRunFill{NI}
     const chips::Vector{Int8}
     const L::Int
     const ff::Int             # samples-per-chip in _RUNFILL_FP fixed point
-    const ni::Int             # padded fixed inner-store count
+    const ni::Int             # padded inner count (used by the NI==0 generic path)
     c::Int                    # current table chip index
     acc::Int                  # chip-start fractional phase (delta & mask)
     pos::Int                  # samples of the current chip already emitted
 end
 
 function CodeGeneratorRunFill(table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int)
-    CodeGeneratorRunFill(table.chips, table.length, _runfill_freqfix(step_num),
-                         _runfill_ni(step_num),
-                         mod(phase_offset, table.length), _RUNFILL_MASK, 0)
+    ni = _runfill_ni(step_num)
+    NI = ni <= _RUNFILL_MAX_NI ? ni : 0      # 0 ⇒ generic kernel (runtime `ni`)
+    CodeGeneratorRunFill{NI}(table.chips, table.length, _runfill_freqfix(step_num),
+                            ni, mod(phase_offset, table.length), _RUNFILL_MASK, 0)
 end
 
-function fill_continue!(out::AbstractVector{<:Integer}, g::CodeGeneratorRunFill)
-    g.c, g.acc, g.pos = _runfill_dispatch!(out, g.chips, g.L, g.ff, g.ni, g.c, g.acc, g.pos)
+function fill_continue!(out::AbstractVector{<:Integer}, g::CodeGeneratorRunFill{NI}) where {NI}
+    g.c, g.acc, g.pos = NI == 0 ?
+        _runfill_seg_generic!(out, g.chips, g.L, g.ff, g.ni, g.c, g.acc, g.pos) :
+        _runfill_seg!(out, g.chips, g.L, g.ff, g.c, g.acc, g.pos, Val(NI))
     out
 end
 

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -528,11 +528,17 @@ end
 
 # Pick the run-fill path when there are at least `_runfill_min_m(backend)` samples per chip.
 # The threshold is the per-chip count where broadcast-fill overtakes the (flat-in-over-
-# sampling) windowed permute, and so depends on how fast that backend's permute is: AVX-512
-# (~36 ps/sample) keeps the permute a little longer than AVX2/NEON (~85 ps); Portable's
-# "permute" is a per-sample scalar lookup, so run-fill wins as soon as runs exist.
-@inline _runfill_min_m(::AVX512)              = 8
-@inline _runfill_min_m(::Union{AVX2,Neon})    = 4
-@inline _runfill_min_m(::Portable)            = 2
+# sampling) windowed permute, so it depends on how fast that backend's permute is. Tuned from
+# a run-fill-vs-permute crossover sweep (AVX-512 measured locally; AVX2/NEON on the CI
+# benchmark runners, x86 Ubuntu + Apple-Silicon macOS):
+#   • AVX-512 `vpermb` is fast (~37 ps/sample), so run-fill only wins from m ≈ 7–8.
+#   • AVX2 `vpshufb` (~85 ps) crosses around m ≈ 4.
+#   • NEON `tbl1` is a 16-wide single-window lookup (slowest permute), so run-fill wins from
+#     m = 3 (m = 2 is a tie).
+#   • Portable's "permute" is a per-sample scalar lookup → run-fill wins as soon as runs exist.
+@inline _runfill_min_m(::AVX512)   = 8
+@inline _runfill_min_m(::AVX2)     = 4
+@inline _runfill_min_m(::Neon)     = 3
+@inline _runfill_min_m(::Portable) = 2
 @inline _use_runfill(step_num::Int, step_den::Int, backend::Backend) =
     step_den ÷ step_num >= _runfill_min_m(backend)

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -87,7 +87,11 @@ function generate_code!(out::AbstractVector{<:Integer}, table::CodeTable,
         throw(ArgumentError("need 0 < step_denominator ≤ 2^$_B"))
     (0 < step_numerator ≤ step_denominator) ||
         throw(ArgumentError("need 0 < step_numerator ≤ step_denominator (must oversample, chips/sample ≤ 1)"))
-    _generate!(out, table, Int(step_numerator), Int(step_denominator), Int(phase), backend)
+    if _use_runfill(Int(step_numerator), Int(step_denominator), backend)
+        _generate_runfill!(out, table, Int(step_numerator), Int(step_denominator), Int(phase))
+    else
+        _generate!(out, table, Int(step_numerator), Int(step_denominator), Int(phase), backend)
+    end
     out
 end
 function generate_code!(out::AbstractVector{<:Integer}, table::CodeTable, cps::Real; kw...)
@@ -335,3 +339,189 @@ end
     end
     out
 end
+
+# ── run-length fill (high-oversampling fast path) ─────────────────────────────────────
+# When the chip rate is far below the sample rate (`m = step_den ÷ step_num` samples per
+# chip is large), the windowed permute is wasteful: a whole W-sample window covers only
+# `W/m` distinct chips, yet the permute recomputes all W lanes. The original `gen_code!`
+# wins here by *broadcast-filling* runs of identical chips — store-bandwidth bound, no
+# per-sample lookup. We do the same directly on the baked ±1 table.
+#
+# DDA. Samples-per-chip `2^_B / step_num` is held in `_RUNFILL_FP`-bit fixed point as
+# `freqfix = round(2^_B · 2^_RUNFILL_FP / step_num)`; a running `delta += freqfix` gives the
+# next chip boundary as `delta >> _RUNFILL_FP`. This is a single short carried add (the store
+# positions pipeline at memory bandwidth) — an exact multiplicative-inverse `base(c)` or a
+# Bresenham remainder recurrence both measured ~2–3× slower (extra multiply / a serialising
+# per-chip compare). The cost is a *rounding* approximation: the boundary can differ from the
+# permute path's exact `ceil(c·2^_B/step_num)` by ≤1–2 samples, but only after ~10⁵ chips —
+# for any single fill the output is byte-identical, and over a long continued stream the
+# drift stays at a couple of samples (same order as the permute path's own documented rate-
+# quantisation drift, and well inside the integer-chip-phase rounding the plan already makes).
+#
+# Like the original's worker, each chip stores a compile-time-fixed `NI ≥ run length` copies
+# (run is `m` or `m+1`) and the next chip's `base` overwrites the ≤ `NI−run` overhang; the
+# main loop is bounds-counted (no per-chip branch) and a scalar tail finishes the remainder.
+# Continuation across fills carries `(chip, acc, pos)`: the table chip index, the fractional
+# accumulator `acc = delta & mask` (chip-start phase), and `pos` = samples of the current
+# chip already emitted (so a fill may resume mid-run). `delta` is re-seeded from `acc` each
+# fill, so it stays bounded by `N·2^_RUNFILL_FP` (no unbounded growth across a long stream).
+
+const _RUNFILL_FP   = 40                       # fractional bits for samples-per-chip
+const _RUNFILL_MASK = (Int(1) << _RUNFILL_FP) - 1
+# Cap a single core call so `delta ≈ N·2^_RUNFILL_FP` stays in Int64 (2^22·2^40 = 2^62);
+# longer buffers are processed in back-to-back segments via the (exact) carried state.
+const _RUNFILL_MAXFILL = 1 << 22
+const _RUNFILL_MAX_NI  = 64                     # largest `Val`-specialised inner count
+
+# samples-per-chip in `_RUNFILL_FP` fixed point. Int128 intermediate: 2^_B·2^FP = 2^70.
+@inline _runfill_freqfix(step_num::Int) =
+    Int((Int128(_STEP_DEN) << _RUNFILL_FP + (step_num >> 1)) ÷ step_num)
+
+# Pad the fixed inner-store count to a value LLVM emits a clean wide store for; min 4 so the
+# `Val` dispatcher always has a branch. Mirrors `GNSSSignals._pad_inner_iterations` but kept
+# local (the baked table is Int8, not the original's Int16, so the ladder may diverge); the
+# over-store is harmless (overwritten), only mild extra store bandwidth.
+@inline function _runfill_pad(x::Int)
+    x <= 4  ? 4  :
+    x <= 8  ? 8  :
+    x == 9  ? 9  :
+    x <= 12 ? 12 :
+    x <= 16 ? 16 :
+    x <= 18 ? x  :
+    x <= 20 ? 20 :
+    x <= 23 ? 24 : x
+end
+
+# Padded inner count for a step (samples/chip ≈ `2^_B / step_num`, run length `m` or `m+1`).
+@inline function _runfill_ni(step_num::Int)
+    m = _STEP_DEN ÷ step_num
+    _runfill_pad(_STEP_DEN % step_num > 0 ? m + 1 : m)
+end
+
+# Fill `out[1:N]` (N ≤ _RUNFILL_MAXFILL) continuing from carried state `(c, acc, pos)`:
+# `c` = table chip index, `acc` = chip-c start phase (delta & mask), `pos` = samples of chip
+# c already emitted. Returns the carried state advanced by N samples. `ff = freqfix`.
+@inline function _runfill_core!(out, chips, L::Int, ff::Int, c::Int, acc::Int, pos::Int, ::Val{NI}) where {NI}
+    N = length(out); FP = _RUNFILL_FP; mask = _RUNFILL_MASK
+    @inbounds begin
+        delta = acc                          # base = delta >> FP = 0 (acc < 2^FP)
+        # head: finish the current chip's run (its first `pos` samples were emitted before)
+        rem_run = ((delta + ff) >> FP) - pos
+        hi = ifelse(rem_run < N, rem_run, N)
+        v = chips[c + 1]
+        for j = 1:hi
+            out[j] = v
+        end
+        hi < rem_run && return (c, acc, pos + N)     # buffer ended inside the current chip
+        # bias `delta` by `pos<<FP` (zero low bits ⇒ `delta & mask` unchanged) so that
+        # `delta >> FP` reads as the buffer position directly (no per-store subtraction).
+        delta += ff - (pos << FP)
+        base = delta >> FP                   # = rem_run (first full-chip boundary)
+        c += 1; c >= L && (c -= L)
+        # main: counted full chips with Val over-store (no per-chip bound check). Conservative
+        # count: base(k)+NI ≤ N is implied by k ≤ (N-NI-1)·2^FP / ff (base(k) < 1 + k·ff/2^FP).
+        rem_samps = N - base
+        nmc = rem_samps > NI ? Int(((Int128(rem_samps - NI)) << FP) ÷ ff) : 0
+        done = 0
+        while done < nmc
+            seg = L - c
+            seg > nmc - done && (seg = nmc - done)
+            for t = 0:seg-1
+                vv = chips[c + t + 1]
+                for j = 1:NI
+                    out[base + j] = vv
+                end
+                delta += ff; base = delta >> FP
+            end
+            c += seg; done += seg
+            c >= L && (c -= L)
+        end
+        # tail: bounds-checked, one run at a time, until the buffer is full
+        while base < N
+            v3 = chips[c + 1]
+            nb = (delta + ff) >> FP
+            hit = ifelse(nb < N, nb, N)
+            for j = base+1:hit
+                out[j] = v3
+            end
+            nb > N && return (c, delta & mask, N - base)   # buffer ended mid-run
+            delta += ff; base = nb
+            c += 1; c >= L && (c -= L)
+        end
+        return (c, delta & mask, 0)          # ended exactly on a chip boundary
+    end
+end
+
+# Runtime-`NI` generic kernel for oversampling above the `Val`-specialised ladder.
+@inline function _runfill_core_generic!(out, chips, L::Int, ff::Int, c::Int, acc::Int, pos::Int, NI::Int)
+    N = length(out); FP = _RUNFILL_FP; mask = _RUNFILL_MASK
+    @inbounds begin
+        delta = acc
+        rem_run = ((delta + ff) >> FP) - pos
+        hi = ifelse(rem_run < N, rem_run, N)
+        v = chips[c + 1]
+        @simd ivdep for j = 1:hi
+            out[j] = v
+        end
+        hi < rem_run && return (c, acc, pos + N)
+        delta += ff - (pos << FP)
+        base = delta >> FP
+        c += 1; c >= L && (c -= L)
+        while base < N
+            v3 = chips[c + 1]
+            nb = (delta + ff) >> FP
+            hit = ifelse(nb < N, nb, N)
+            @simd ivdep for j = base+1:hit
+                out[j] = v3
+            end
+            nb > N && return (c, delta & mask, N - base)
+            delta += ff; base = nb
+            c += 1; c >= L && (c -= L)
+        end
+        return (c, delta & mask, 0)
+    end
+end
+
+# Dispatch on the (padded) fixed inner count `ni`. `Val(ni)` from a runtime `ni` costs one
+# dynamic dispatch per call (negligible against a whole-buffer fill) and — unlike an
+# `@generated`/if-ladder over all of `4:_RUNFILL_MAX_NI` — only forces inference + codegen of
+# the `Val{NI}` specialisations actually used at a given rate, keeping first-call latency low.
+@inline function _runfill_call!(out, chips, L::Int, ff::Int, c::Int, acc::Int, pos::Int, ni::Int)
+    ni > _RUNFILL_MAX_NI ?
+        _runfill_core_generic!(out, chips, L, ff, c, acc, pos, ni) :
+        _runfill_core!(out, chips, L, ff, c, acc, pos, Val(ni))
+end
+
+# Fill `out` (any length) continuing from `(c, acc, pos)`, segmenting into ≤ _RUNFILL_MAXFILL
+# chunks so the per-call `delta` cannot overflow. Returns the advanced carried state.
+function _runfill_dispatch!(out, chips, L::Int, ff::Int, ni::Int, c::Int, acc::Int, pos::Int)
+    N = length(out)
+    if N <= _RUNFILL_MAXFILL
+        return _runfill_call!(out, chips, L, ff, c, acc, pos, ni)
+    end
+    o = 0
+    while o < N
+        seg = min(N - o, _RUNFILL_MAXFILL)
+        c, acc, pos = _runfill_call!(view(out, o+1:o+seg), chips, L, ff, c, acc, pos, ni)
+        o += seg
+    end
+    (c, acc, pos)
+end
+
+# One-shot run-fill from chip phase, sample 0 (acc = mask gives the `ceil`-boundary rounding
+# that matches the permute path; pos = 0).
+function _generate_runfill!(out, table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int)
+    _runfill_dispatch!(out, table.chips, table.length, _runfill_freqfix(step_num),
+                       _runfill_ni(step_num), mod(phase_offset, table.length), _RUNFILL_MASK, 0)
+end
+
+# Pick the run-fill path when there are at least `_runfill_min_m(backend)` samples per chip.
+# The threshold is the per-chip count where broadcast-fill overtakes the (flat-in-over-
+# sampling) windowed permute, and so depends on how fast that backend's permute is: AVX-512
+# (~36 ps/sample) keeps the permute a little longer than AVX2/NEON (~85 ps); Portable's
+# "permute" is a per-sample scalar lookup, so run-fill wins as soon as runs exist.
+@inline _runfill_min_m(::AVX512)              = 8
+@inline _runfill_min_m(::Union{AVX2,Neon})    = 4
+@inline _runfill_min_m(::Portable)            = 2
+@inline _use_runfill(step_num::Int, step_den::Int, backend::Backend) =
+    step_den ÷ step_num >= _runfill_min_m(backend)

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -514,16 +514,31 @@ function _runfill_seg_generic!(out, chips, L::Int, ff::Int, ni::Int, c::Int, acc
     (c, acc, pos)
 end
 
+# Statically dispatch a runtime padded `ni` to the matching `Val{NI}` run-fill kernel via an
+# explicit branch ladder (`i = 4:_RUNFILL_MAX_NI`); above the ladder the runtime-`NI` generic
+# kernel takes over. Lifting a runtime `Val(ni)` instead would box once per call, so this keeps
+# the one-shot path 0-alloc — the same trick (and ladder range) as `dispatch_sample_code_worker!`
+# for the original `gen_code!`. `_runfill_ni` floors at 4, so the ladder never sees 1..3.
+@generated function _runfill_seg_dispatch!(out, chips, L::Int, ff::Int, ni::Int,
+                                           c::Int, acc::Int, pos::Int)
+    branches = [
+        :(ni == $i && return _runfill_seg!(out, chips, L, ff, c, acc, pos, Val($i)))
+        for i = 4:_RUNFILL_MAX_NI
+    ]
+    quote
+        $(branches...)
+        return _runfill_seg_generic!(out, chips, L, ff, ni, c, acc, pos)
+    end
+end
+
 # One-shot run-fill from chip phase, sample 0 (acc = mask gives the `ceil`-boundary rounding
-# that matches the permute path; pos = 0). `Val(ni)` is a runtime lift here (one box per
-# one-shot call — negligible, the call already builds a generator); the *continuing*
-# generator stays 0-alloc by carrying `NI` in its type (see `CodeGeneratorRunFill`).
+# that matches the permute path; pos = 0). Dispatches to the `Val{NI}`-specialised kernel
+# allocation-free; the *continuing* generator stays 0-alloc by carrying `NI` in its type
+# (see `CodeGeneratorRunFill`).
 function _generate_runfill!(out, table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int)
     ff = _runfill_freqfix(step_num); ni = _runfill_ni(step_num)
-    c = mod(phase_offset, table.length); chips = table.chips; L = table.length
-    ni > _RUNFILL_MAX_NI ?
-        _runfill_seg_generic!(out, chips, L, ff, ni, c, _RUNFILL_MASK, 0) :
-        _runfill_seg!(out, chips, L, ff, c, _RUNFILL_MASK, 0, Val(ni))
+    c = mod(phase_offset, table.length)
+    _runfill_seg_dispatch!(out, table.chips, table.length, ff, ni, c, _RUNFILL_MASK, 0)
 end
 
 # Pick the run-fill path when there are at least `_runfill_min_m(backend)` samples per chip.

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -482,37 +482,48 @@ end
     end
 end
 
-# Dispatch on the (padded) fixed inner count `ni`. `Val(ni)` from a runtime `ni` costs one
-# dynamic dispatch per call (negligible against a whole-buffer fill) and — unlike an
-# `@generated`/if-ladder over all of `4:_RUNFILL_MAX_NI` — only forces inference + codegen of
-# the `Val{NI}` specialisations actually used at a given rate, keeping first-call latency low.
-@inline function _runfill_call!(out, chips, L::Int, ff::Int, c::Int, acc::Int, pos::Int, ni::Int)
-    ni > _RUNFILL_MAX_NI ?
-        _runfill_core_generic!(out, chips, L, ff, c, acc, pos, ni) :
-        _runfill_core!(out, chips, L, ff, c, acc, pos, Val(ni))
-end
-
 # Fill `out` (any length) continuing from `(c, acc, pos)`, segmenting into ≤ _RUNFILL_MAXFILL
-# chunks so the per-call `delta` cannot overflow. Returns the advanced carried state.
-function _runfill_dispatch!(out, chips, L::Int, ff::Int, ni::Int, c::Int, acc::Int, pos::Int)
+# chunks so the per-call `delta` cannot overflow. `NI` is a compile-time constant (the inner
+# store trip count), so the `Val{NI}` kernel dispatches statically — 0 allocations per call.
+function _runfill_seg!(out, chips, L::Int, ff::Int, c::Int, acc::Int, pos::Int, ::Val{NI}) where {NI}
     N = length(out)
     if N <= _RUNFILL_MAXFILL
-        return _runfill_call!(out, chips, L, ff, c, acc, pos, ni)
+        return _runfill_core!(out, chips, L, ff, c, acc, pos, Val(NI))
     end
     o = 0
     while o < N
         seg = min(N - o, _RUNFILL_MAXFILL)
-        c, acc, pos = _runfill_call!(view(out, o+1:o+seg), chips, L, ff, c, acc, pos, ni)
+        c, acc, pos = _runfill_core!(view(out, o+1:o+seg), chips, L, ff, c, acc, pos, Val(NI))
+        o += seg
+    end
+    (c, acc, pos)
+end
+
+# Generic (runtime-`NI`) segmented wrapper for oversampling above the `Val` ladder.
+function _runfill_seg_generic!(out, chips, L::Int, ff::Int, ni::Int, c::Int, acc::Int, pos::Int)
+    N = length(out)
+    if N <= _RUNFILL_MAXFILL
+        return _runfill_core_generic!(out, chips, L, ff, c, acc, pos, ni)
+    end
+    o = 0
+    while o < N
+        seg = min(N - o, _RUNFILL_MAXFILL)
+        c, acc, pos = _runfill_core_generic!(view(out, o+1:o+seg), chips, L, ff, c, acc, pos, ni)
         o += seg
     end
     (c, acc, pos)
 end
 
 # One-shot run-fill from chip phase, sample 0 (acc = mask gives the `ceil`-boundary rounding
-# that matches the permute path; pos = 0).
+# that matches the permute path; pos = 0). `Val(ni)` is a runtime lift here (one box per
+# one-shot call — negligible, the call already builds a generator); the *continuing*
+# generator stays 0-alloc by carrying `NI` in its type (see `CodeGeneratorRunFill`).
 function _generate_runfill!(out, table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int)
-    _runfill_dispatch!(out, table.chips, table.length, _runfill_freqfix(step_num),
-                       _runfill_ni(step_num), mod(phase_offset, table.length), _RUNFILL_MASK, 0)
+    ff = _runfill_freqfix(step_num); ni = _runfill_ni(step_num)
+    c = mod(phase_offset, table.length); chips = table.chips; L = table.length
+    ni > _RUNFILL_MAX_NI ?
+        _runfill_seg_generic!(out, chips, L, ff, ni, c, _RUNFILL_MASK, 0) :
+        _runfill_seg!(out, chips, L, ff, c, _RUNFILL_MASK, 0, Val(ni))
 end
 
 # Pick the run-fill path when there are at least `_runfill_min_m(backend)` samples per chip.

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -164,6 +164,65 @@ const _BACKENDS = (CL.Portable(),
         end
     end
 
+    @testset "high-oversampling run-fill path" begin
+        # At high oversampling `make_generator` / `generate_code!` switch from the windowed
+        # permute to a broadcast run-fill (`_runfill_*`). Its approximate samples-per-chip DDA
+        # matches the exact `floor(step_num·n/2^_B)` fixed-point reference for any single fill
+        # (the rounding drift only reaches ≤1 sample after ~10⁶ chips — see the drift test
+        # below), so here it must be byte-identical. Sweep `m = samples/chip` across the
+        # `Val`-specialised ladder AND the `m > 64` generic kernel, with non-power-of-two
+        # rates (`m`/`m+1` mixed runs), several phases/lengths, and chunked continuation.
+        rng = MersenneTwister(99)
+        for L in (1023, 257, 64)
+            chips = rand(rng, Int8[-1, 1], L); ct = CL.CodeTable(chips)
+            # cps chosen to hit a spread of samples-per-chip incl. exact (power-of-two) and
+            # fractional, the ladder rungs (≈16,20,24,32,48,64), and the generic m>64 path.
+            for cps in (1 / 8, 1 / 16, 0.0613, 1 / 32, 0.019, 1 / 64, 0.013, 0.004)
+                sn = _step_num(cps)
+                for phase in (0, 7, L - 1)
+                    n = 4 * 1024 + 37                     # not stride-aligned
+                    ref = _ref(chips, sn, phase, n)
+                    for be in _BACKENDS
+                        # one-shot
+                        out = Vector{Int8}(undef, n)
+                        CL.generate_code!(out, ct, cps; phase = phase, backend = be)
+                        @test out == ref
+                        # continuing, uneven chunks across run boundaries
+                        gen = CL.make_generator(ct, cps; phase = phase, backend = be)
+                        got = Int8[]
+                        for chunk in (1, 333, 64, 2048, n - 1 - 333 - 64 - 2048)
+                            buf = Vector{Int8}(undef, chunk)
+                            CL.fill_continue!(buf, gen)
+                            append!(got, buf)
+                        end
+                        @test got == ref
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "run-fill long-sequence drift + >MAXFILL segmentation" begin
+        chips = rand(MersenneTwister(7), Int8[-1, 1], 1023); ct = CL.CodeTable(chips)
+        # Drift bound: over a long single fill (millions of chips) the approximate DDA may
+        # differ from the exact floor reference, but only by a couple of samples at boundaries.
+        for cps in (1 / 8, 0.0613)            # exact and fractional run-fill rates
+            sn = _step_num(cps); n = 3_000_000
+            ref = _ref(chips, sn, 0, n)
+            out = Vector{Int8}(undef, n)
+            CL.generate_code!(out, ct, cps; backend = CL.Portable())
+            @test count(!=(0), out .- ref) <= 4      # ≤ a few sub-chip-boundary shifts
+        end
+        # Buffers longer than `_RUNFILL_MAXFILL` exercise the internal segmentation loop (which
+        # caps the per-call accumulator). The segmented output must still track the floor
+        # reference to within the same small drift bound.
+        n = CL._RUNFILL_MAXFILL + 12345; sn = _step_num(1 / 16)
+        @test n > CL._RUNFILL_MAXFILL                       # segmentation actually triggered
+        out = Vector{Int8}(undef, n)
+        CL.generate_code!(out, ct, sn, CL._STEP_DEN; backend = CL.Portable())
+        @test count(!=(0), out .- _ref(chips, sn, 0, n)) <= 4
+    end
+
     @testset "modulation (BOC / TMBOC / secondary)" begin
         # Independent reference: build the FULL primary×secondary×subcarrier ±1 table and
         # index it at the sub-chip fixed-point rate `a/b` (sub-chips/sample, ≤ 1). The
@@ -342,5 +401,36 @@ end
         @test P > 1
         fc1c = get_code_frequency(plan.signal)
         @test_throws ErrorException code_engine(plan, Float64(fc1c) * P / 2, fc1c, Val(1))
+    end
+
+    # End-to-end public adapter at HIGH oversampling, where the engine uses the broadcast
+    # run-fill rather than the permute. The one-shot `gen_code!(out, plan, …)` and a *warm*
+    # continuing `gen_code!(out, gen)` must produce the identical fill, and chunked
+    # continuation must concatenate to one big generation — exercising the run-fill across
+    # call boundaries together with the per-primary-period secondary negate (GPS L5I NH10).
+    @testset "plan/generator run-fill at high oversampling (L1CA + L5I secondary)" begin
+        for (signal, osr) in ((GPSL1CA(), 40), (GPSL5I(), 32))   # L5I carries the NH10 secondary
+            plan = CodeReplicaLUT(signal, 1)
+            fc = get_code_frequency(plan.signal)
+            fs = Float64(fc) * osr * plan.mc.subchip_factor
+            N = 7000
+            # one-shot (builds + run-fills from phase 0)
+            oneshot = Vector{Int8}(undef, N)
+            gen_code!(oneshot, plan, fs, fc)
+            # warm continuing generator, single fill of N
+            gen = CodeGeneratorLUT(plan, fs, fc)
+            warm = Vector{Int8}(undef, N)
+            gen_code!(warm, gen)
+            @test warm == oneshot
+            # chunked continuation == one big generation (crosses run + secondary-period boundaries)
+            gen2 = CodeGeneratorLUT(plan, fs, fc)
+            got = Int8[]
+            for chunk in (1, 999, 64, 4096, N - 1 - 999 - 64 - 4096)
+                buf = Vector{Int8}(undef, chunk)
+                gen_code!(buf, gen2)
+                append!(got, buf)
+            end
+            @test got == oneshot
+        end
     end
 end


### PR DESCRIPTION
Builds on #69 (targets `feat/code-lut-resampler`).

## Problem

The LUT resampler does one windowed `vpermb`/`vpshufb` permute per `W`-sample window **regardless of oversampling**, so its cost is *flat* in the oversampling ratio. At high oversampling each window spans only a couple of distinct chips, yet the permute still recomputes all `W` lanes — wasted work. The original `gen_code!` wins there by broadcast-filling runs of identical chips (store-bandwidth bound). The result was the LUT being **5–12× slower** than the original for plain BPSK at OSR ≳ 16 (worst on AVX2), as the [benchmark CI comment](https://github.com/JuliaGNSS/GNSSSignals.jl/pull/69#issuecomment-4793382612) showed.

## Change

Add a **broadcast run-fill** fast path on the existing baked `Int8` table (no larger arrays — same table), selected per-backend once the baked table is oversampled enough that the permute loses: **m ≥ 8** on AVX-512, **4** on AVX2, **3** on NEON, **2** on Portable (crossovers measured on the benchmark CI — see below) (`m = step_den ÷ step_num` = samples per baked chip).

- Each chip broadcast-fills a compile-time-fixed `NI ≥ run-length` copies (`Val`-dispatched, padded ladder), with the next chip's boundary overwriting the overhang; a **counted** main loop keeps the inner store branch-free and a scalar tail finishes the remainder.
- The continuing generator carries `(chip, acc, pos)` so fills resume seamlessly mid-run.
- Chip boundaries come from a fixed-point samples-per-chip DDA (`delta += freqfix` — a single short carried add, so the stores pipeline at memory bandwidth). An exact multiplicative-inverse `base(c)` and a Bresenham remainder recurrence both measured ~2–3× slower (extra multiply / a serialising per-chip compare).

### Approximation

The `delta += freqfix` DDA is a **rounding approximation**: chip boundaries are **exact for any single fill**, and drift at most ~1–2 samples only over a *very* long continued stream (~10⁶ chips) — the same order as the permute path's own documented rate-quantisation drift, and well inside the integer-chip-phase rounding the plan already makes. The per-call accumulator is segmented at `2²²` samples so it can never overflow `Int64` on large buffers (a latent overflow the exact prototype actually had). All backends stay byte-identical at realistic fill sizes.

## Results (64k samples, ratio = orig/LUT, >1 = LUT faster)

| signal / backend | os=2 | os=4 | os=8 | os=16 | os=32 | os=64 |
|---|---|---|---|---|---|---|
| **BPSK — before** | 2.7× | — | 0.69× | 0.37× | **0.20×** | **0.19×** |
| **BPSK — AVX-512** | 2.7× | 1.4× | 0.84× | 0.87× | 0.84× | **1.5×** |
| **BPSK — AVX2** | 1.2× | 0.88× | 0.84× | 0.89× | 0.86× | **1.5×** |
| **BOC(1,1) — AVX-512** | 3.8× | 2.5× | 1.8× | 1.8× | **3.3×** | **5.4×** |
| **BOC(1,1) — AVX2** | 1.7× | 1.1× | 1.2× | 1.8× | **3.3×** | **5.6×** |

Plain BPSK is now within **0.84–0.89×** of the original across all oversampling (worst case 16% slower, down from 5–12× slower) and wins at low/very-high OSR. BOC/TMBOC win everywhere (baked subcarrier). The residual BPSK gap is the inherent `Int8`-output vs the original's `Int16` store-codegen difference.

## Tests

Adds run-fill coverage to `test/code_lut.jl`: the `Val`-ladder + generic (`NI>64`) kernel, several phases/lengths, chunked continuation across run boundaries, the long-sequence drift bound, and the `>MAXFILL` segmentation path. Plus an end-to-end adapter test (`CodeGeneratorLUT` one-shot vs warm continuing, incl. the GPS L5I NH10 secondary). Full suite green (1032 LUT assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Benchmark-CI findings (NEON / AVX2 crossover + 0-alloc)

The `Benchmarks` workflow only runs on PRs based on `master`, so I confirmed these on a temporary probe PR (now closed) that ran the suite on the Ubuntu (x86) and macOS (Apple-Silicon / NEON) runners:

- **0-alloc regression caught & fixed.** The first cut dispatched the inner-store count via `Val(ni)` lifted from a runtime value — that boxes (~96 B/call) and broke the warm `CodeGeneratorLUT`'s 0-alloc steady state. Now `NI` is a type parameter of the engine, so the hot fill dispatches statically (commit 2). Verified 0 allocs across all oversampling.
- **NEON threshold tuned 4 → 3.** A fine run-fill-vs-permute sweep showed NEON's `tbl1` permute is ~15.5 µs flat (64k), so run-fill already wins from **m = 3** (m = 2 is a tie). AVX2's crossover sits at ~m = 4 on real hardware, confirming that threshold (commit 3).