### PR TITLE
ci: benchmark PRs based on any branch, compare against the PR's base

### DIFF
--- a/.github/scripts/min_table.jl
+++ b/.github/scripts/min_table.jl
@@ -50,7 +50,11 @@ names = sort(collect(union(keys(base), keys(head))))
 filter!(!=("time_to_load"), names)
 (haskey(base, "time_to_load") || haskey(head, "time_to_load")) && push!(names, "time_to_load")
 
-headlbl = length(head_rev) >= 8 ? head_rev[1:8] * "…" : head_rev
+# Truncate long revs (e.g. a base/head commit SHA) for display; the full rev is still used
+# above to locate the result JSONs.
+shortrev(rev) = length(rev) >= 16 && !occursin('/', rev) ? rev[1:8] * "…" : rev
+headlbl = shortrev(head_rev)
+baselbl = shortrev(base_rev)
 
 io = IOBuffer()
 title = isempty(label) ? "Benchmark Results (minimum time)" :
@@ -58,7 +62,7 @@ title = isempty(label) ? "Benchmark Results (minimum time)" :
 println(io, "## $title")
 println(io)
 println(io, "Reporting the **minimum** over all samples (robust to shared-runner contention), ",
-            "not the median. Ratio = $base_rev / $headlbl: **>1 means the PR is faster**. ",
+            "not the median. Ratio = $baselbl / $headlbl: **>1 means the PR is faster**. ",
             "✅ ≥ 5 % faster, ⚠️ ≥ 5 % slower. A blank cell means that benchmark exists on only ",
             "one revision (🆕 = new on the PR, 🗑 = removed).")
 println(io)
@@ -66,7 +70,7 @@ println(io)
 # --- time table ---
 println(io, "<details open><summary>Time benchmarks</summary>")
 println(io)
-println(io, "|  | $base_rev | $headlbl | $base_rev / $headlbl |")
+println(io, "|  | $baselbl | $headlbl | $baselbl / $headlbl |")
 println(io, "|:--|--:|--:|--:|")
 for n in names
     b = get(base, n, nothing); h = get(head, n, nothing)
@@ -87,7 +91,7 @@ println(io)
 # --- memory table ---
 println(io, "<details><summary>Memory benchmarks</summary>")
 println(io)
-println(io, "|  | $base_rev | $headlbl |")
+println(io, "|  | $baselbl | $headlbl |")
 println(io, "|:--|--:|--:|")
 for n in names
     b = get(base, n, nothing); h = get(head, n, nothing)

--- a/.github/workflows/Benchmarks.yml
+++ b/.github/workflows/Benchmarks.yml
@@ -1,6 +1,6 @@
 name: Benchmarks
 
-# Compares the PR head against the default branch with AirspeedVelocity's `benchpkg`,
+# Compares the PR head against the PR's *base* branch with AirspeedVelocity's `benchpkg`,
 # but reports the **minimum** time per benchmark instead of its built-in median table.
 # The minimum is far more robust to noisy-neighbour contention on shared GitHub runners
 # (it captures the least-disturbed sample), so it doesn't manufacture phantom regressions
@@ -9,16 +9,24 @@ name: Benchmarks
 # Runs on both x86 (Ubuntu) and ARM (Apple Silicon, macos-14) so the NEON code path gets
 # benchmarked on real Apple-Silicon hardware, not just the x86 AVX2/AVX-512 paths.
 #
+# No `branches:` filter, so this runs for PRs targeting *any* base branch (e.g. stacked PRs
+# whose base is a feature branch), comparing head against that PR's own base — not always the
+# default branch. NOTE: for `pull_request_target` GitHub reads this workflow (and its `on:`
+# filters) from the PR's BASE branch, so this behaviour only applies to PRs whose base branch
+# already contains this version of the file (it must be merged to `master`, and to any
+# feature branch used as a base, to take effect there).
+#
 # Security: runs as pull_request_target so the comment-posting token has write access.
 # The repo is checked out at the *base* (trusted) ref, and benchpkg benchmarks the PR's
 # own benchmark/benchmarks.jl via --bench-on=<head sha>. GITHUB_TOKEN is blanked for
 # every step that builds/executes benchmark code; only the comment steps see the token.
 on:
   pull_request_target:
-    branches: [main, master]
 
+# Key the concurrency group on the PR number (not the base ref): a new push to a PR cancels
+# that PR's own in-flight run, but PRs sharing a base branch don't cancel each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -66,7 +74,7 @@ jobs:
           mkdir -p results
           benchpkg GNSSSignals \
             --url=${{ github.event.repository.clone_url }} \
-            --rev=${{ github.event.repository.default_branch }},${{ github.event.pull_request.head.sha }} \
+            --rev=${{ github.event.pull_request.base.sha }},${{ github.event.pull_request.head.sha }} \
             --bench-on=${{ github.event.pull_request.head.sha }} \
             --add=Unitful \
             --output-dir=results/ \
@@ -77,7 +85,7 @@ jobs:
           GITHUB_TOKEN: ""
         run: |
           julia .github/scripts/min_table.jl results GNSSSignals \
-            "${{ github.event.repository.default_branch }}" \
+            "${{ github.event.pull_request.base.sha }}" \
             "${{ github.event.pull_request.head.sha }}" \
             "${{ matrix.runner }}" > body.md
           cat body.md


### PR DESCRIPTION
## What

Make the `Benchmarks` workflow run on PRs targeting **any** base branch (e.g. stacked PRs whose base is a feature branch), not just `main`/`master`, and compare the head against the **PR's own base** rather than always the default branch.

- Drop the `on.pull_request_target.branches: [main, master]` filter.
- `benchpkg --rev` and the comment-table base label now use `github.event.pull_request.base.sha` instead of `repository.default_branch`, so a stacked PR's table reflects only that PR's diff (not its base branch's changes too). For PRs targeting `master` this is identical to before.
- `min_table.jl` truncates a commit-SHA base/head label for display (full SHA still used to find the result JSONs).
- Concurrency keyed per PR number, so PRs sharing a base branch don't cancel each other.

## Important: how this takes effect

For `pull_request_target`, GitHub reads the workflow file **and its `on:` filters from the PR's base branch** — never from the PR head. So:

- This change must be **merged to `master`** to benefit PRs that target `master` (it can't be activated from a PR branch).
- To benchmark a PR whose base is a **feature branch** (e.g. a stacked PR), that feature branch must also contain this version of the file. Branches cut from an updated `master` get it automatically; existing feature branches need it merged/cherry-picked in.

No behaviour change for PRs to `master` other than the (equivalent) base reference; the new capability is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
