### PR TITLE
bench: full Early/Prompt/Late correlation with shared carrier wipe-off

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -163,44 +163,54 @@ let fc = 1023e3Hz
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Correlation signal path — FUSED vs UNFUSED.
+# Correlation signal path — FUSED vs UNFUSED, full Early / Prompt / Late (E/P/L).
 #
-# Models one tracking correlation with a realistic front-end word layout:
-#   measurement — COMPLEX, Int16, re/im interleaved as [reₙ, imₙ, …] (one 12-bit ADC sample
-#                 per component, |m| ≲ 2048); a single Vector{Int16} of length 2·N.
-#   carrier     — Int8, small configurable amplitude (the complex local carrier cos + j·sin)
-#   code        — Int8 ±1 replica (a CBOC/BOC replica can reach ±2)
-# The correlator output is the complex sum of measurement × code × conj(cos + j·sin):
-#   I (real) = Σ code·(mᵣ·cos + mᵢ·sin),   Q (imag) = Σ code·(mᵢ·cos − mᵣ·sin).
-# Per-sample products exceed Int16 (2048·8·2 = 32768), so both arms accumulate into Int32.
-# The hot multiply uses `vpmaddwd` (Int16×Int16 → Int32 pairwise multiply-add) where available:
-# it forms the product at Int32 width (no overflow, no Int16 staging) and its pairwise reduction
-# halves the accumulator lane count, so on AVX-512 the kernel is allocation-free where the plain
-# widen-to-Int32 path spills the wide `Vec{64,Int32}` accumulators. The interleaved measurement
-# is deinterleaved into mᵣ/mᵢ once per chunk; `mᵣ·code` / `mᵢ·code` (≤ ±4096, fit Int16) feed the
-# four pmaddwd terms. Platforms without `vpmaddwd` (NEON/scalar) fall back to a plain Int32
-# multiply at the backend's native width; both paths give identical results.
+# Models one tracking update with the three standard correlators. Front-end words:
+#   measurement — COMPLEX Int16, re/im interleaved [reₙ, imₙ, …] (12-bit ADC, |m| ≲ 2048),
+#                 a single Vector{Int16} of length 2·N.
+#   carrier     — Int8, small amplitude (local carrier cos + j·sin); SHARED by E/P/L.
+#   code        — Int8 ±1 replica (CBOC/BOC can reach ±2); Early/Late are the Prompt code
+#                 shifted by ∓D samples (½-chip spacing ⇒ D = round(0.5·fs/fc)).
+# Per-correlator output is the complex sum of measurement × codeₓ × conj(cos + j·sin):
+#   Iₓ = Σ codeₓ·(mᵣ·cos + mᵢ·sin),   Qₓ = Σ codeₓ·(mᵢ·cos − mᵣ·sin),   x ∈ {E, P, L}.
 #
-#   UNFUSED — materialise the code and carrier into preallocated Int8 buffers (gen_code! +
-#             generate_carrier!), then stream the buffers + measurement through the
-#             correlation loop. Extra memory passes; buffers preallocated once.
-#   FUSED   — never materialise code/carrier: drive the value-based code/carrier engines
-#             (`code_engine` + `carrier_engine`) straight into the correlation loop. Both are
-#             loop-invariant and built once; the hot loop holds 4 isbits states W samples apart
-#             (built with `Val(4)` for code, `carrier_state(eng, kW)` for carrier) so four
-#             DDA/NCO carry chains overlap (full ILP, fastest). Each `code_lookup`/`carrier_lookup`
-#             returns an Int8 SIMD chunk in registers; the states are renewed by value with
-#             `code_advance`/`carrier_advance` — no heap, nothing materialised. The < 4·W tail is
-#             finished by single-wide engines (code `Val(1)` positioned at the tail's start
-#             sample; the carrier engine is interleave-agnostic and reused with `carrier_advance(…, 1)`),
-#             and the final < W samples are absorbed by zero-padding `meas` to a W multiple
-#             (padding · anything = 0) — so no slow scalar remainder.
+# SHARED CARRIER WIPE-OFF. The carrier is identical for all three correlators, so the
+# per-sample wipe DI = mᵣ·cos + mᵢ·sin, DQ = mᵢ·cos − mᵣ·sin is computed ONCE and each
+# correlator reduces to a cheap Σ codeₓ·DI / Σ codeₓ·DQ — ~1.8× faster than three
+# independent correlations. The wipe is a per-sample complex multiply: deinterleave mᵣ/mᵢ,
+# widen everything to Int32 and multiply (per-sample products reach 2048·8·2 = 32768 > Int16,
+# so DI/DQ are Int32). The code step is then an Int32 multiply (code ±1, CBOC/BOC ±2) into the
+# accumulators. NOTE: `vpmaddwd` is deliberately NOT used here. It packs an Int16×Int16→Int32
+# *pairwise sum*, which only pays off when the output is a reduced sum; the wipe output is
+# per-sample, so the interleave + shuffles `vpmaddwd` needs are pure overhead — the straight
+# deinterleave-and-multiply is ~17–25 % faster (measured on AVX-512) and identical on NEON,
+# which has no `vpmaddwd` anyway. (Keeping DI/DQ in Int16 to re-enable `vpmaddwd` for the code
+# step was tried and is a wash: the kernel is bound by the lookup/shuffle work, not the
+# multiply width.)
 #
-# GPS L1 C/A, 5 MHz, 1 ms ⇒ N = 5000 samples. Carrier amplitude and ADC bit depth are
-# configurable (the `carrier_amplitude` / `adc_bits` locals below). The plan (CodeReplicaLUT),
-# SinCosTable, the value-based engines, the warm unfused generator and the buffers are all built
-# once in setup (a receiver reuses them); the timed region only creates the cheap isbits states
-# and runs the correlation loop.
+# EARLY/LATE = PROMPT SHIFTED BY D SAMPLES. One Prompt code stream is built; Early/Late index
+# it ∓D samples away. This generates the code ONCE (N+2D samples) instead of three times and
+# — crucially — it FUSES: the fused kernel looks the Prompt code up once per W-wide chunk and
+# derives Early/Late by register lane-shifts across the carried neighbouring chunks (a
+# `shufflevector`). With width W the shift spans ⌈D/W⌉ neighbour chunks, so the kernel carries
+# a small sliding pipeline of P = ⌈D/W⌉+⌊D/W⌋+2 code chunks (registers only; one lookup + one
+# DDA advance + two shuffles per chunk, independent of the correlator count). The alternative
+# (generate Early/Late independently — three lookups + advances) is ~20–25 % slower and, when
+# fused, can't even express a sub-chip spacing (the value-based code engine takes an
+# integer-chip phase offset), so the sample-shift is the natural fused form.
+#
+#   UNFUSED — materialise ONE extended Prompt code buffer (samples −D … N−1+D) + the shared
+#             carrier into Int8 buffers, then stream them through the shared-wipe loop with
+#             Early/Prompt/Late as offset reads (ext[n] / ext[n+D] / ext[n+2D]).
+#   FUSED   — never materialise: drive the value-based Prompt code engine + carrier engine
+#             straight into the loop; Early/Late are lane-shifts of the looked-up Prompt code.
+#
+# Code before sample 0 is taken as zero (a D-sample edge on Early only; applied identically to
+# fused / unfused / a scalar reference, so all three stay bit-for-bit equal). The < W
+# measurement tail rides on the zero-padding of `meas` to a W multiple (padding · anything = 0).
+# Benchmarked at GPS L1 C/A 1 ms for two rates: 5 MHz (N=5000, D=2) and 40 MHz (N=40000, D=20;
+# there D > W on NEON, exercising the multi-chunk pipeline). Plans / tables / engines / buffers
+# are built once in setup (a receiver reuses them); the timed region runs the correlation loop.
 # ─────────────────────────────────────────────────────────────────────────────
 # SIMD width of the Int8 carrier/code permute backend on this host (compile-time const).
 # Derived from SinCosLUT (always available); the code LUT uses the same Int8 width per
@@ -213,239 +223,127 @@ const _CORR_W = let be = SinCosLUT.default_backend(Int8, 64)
     be isa SinCosLUT.Neon ? 16 : 1
 end
 
-# `pmaddwd` exists on AVX2 (256-bit) and AVX-512BW (512-bit) — i.e. whenever the Int8
-# code/carrier backend is AVX2 (W=32) or AVX-512 (W=64). NEON has no direct equivalent
-# (its `smull`/`smlal` widening multiply is what the portable Int32 path lowers to), and
-# the scalar fallback (W=1) has none either, so both use `_accum_portable!`.
-const _HAS_VPMADDWD = _CORR_W == 32 || _CORR_W == 64
-
-@inline _wide16(v::Vec{W,Int8}) where {W} = convert(Vec{W,Int16}, v)
 @inline _wide32(v::Vec{W,Int8}) where {W} = convert(Vec{W,Int32}, v)
 @inline _wide32(v::Vec{W,Int16}) where {W} = convert(Vec{W,Int32}, v)
-
-# Lower / upper half of a vector (free: selects one register half of the wider vector).
-@inline _lo(v::Vec{W,T}) where {W,T} = shufflevector(v, Val(ntuple(i -> i - 1, Val(W ÷ 2))))
-@inline _hi(v::Vec{W,T}) where {W,T} = shufflevector(v, Val(ntuple(i -> i - 1 + W ÷ 2, Val(W ÷ 2))))
 
 # Deinterleave [re, im, …] → real (even lanes) / imag (odd lanes), Vec{2W,Int16} → Vec{W,Int16}.
 @inline _re(v::Vec{M,Int16}) where {M} = shufflevector(v, Val(ntuple(i -> 2 * (i - 1), Val(M ÷ 2))))
 @inline _im(v::Vec{M,Int16}) where {M} = shufflevector(v, Val(ntuple(i -> 2 * (i - 1) + 1, Val(M ÷ 2))))
 
-# pmaddwd: a,b Int16 → Int32, dst[j] = a[2j]·b[2j] + a[2j+1]·b[2j+1] (each product formed at
-# Int32 width, so no Int16 overflow). Reached via llvmcall as SIMD.jl does not expose it; one
-# variant per register width. Only *called* on the matching backend (so the avx512 form is
-# never lowered on an AVX2 host and vice versa), but defining both unconditionally is harmless.
-@inline function _vpmaddwd(a::Vec{32,Int16}, b::Vec{32,Int16})   # AVX-512BW (512-bit)
-    Vec(Base.llvmcall(
-        (raw"""
-         declare <16 x i32> @llvm.x86.avx512.pmaddw.d.512(<32 x i16>, <32 x i16>)
-         define <16 x i32> @entry(<32 x i16> %a, <32 x i16> %b) #0 {
-         top:
-           %r = call <16 x i32> @llvm.x86.avx512.pmaddw.d.512(<32 x i16> %a, <32 x i16> %b)
-           ret <16 x i32> %r
-         }
-         attributes #0 = { "target-features"="+avx512f,+avx512bw,+avx512vl" }
-         """, "entry"),
-        NTuple{16,Base.VecElement{Int32}},
-        Tuple{NTuple{32,Base.VecElement{Int16}},NTuple{32,Base.VecElement{Int16}}},
-        a.data, b.data))
-end
-@inline function _vpmaddwd(a::Vec{16,Int16}, b::Vec{16,Int16})   # AVX2 (256-bit)
-    Vec(Base.llvmcall(
-        (raw"""
-         declare <8 x i32> @llvm.x86.avx2.pmadd.wd(<16 x i16>, <16 x i16>)
-         define <8 x i32> @entry(<16 x i16> %a, <16 x i16> %b) #0 {
-         top:
-           %r = call <8 x i32> @llvm.x86.avx2.pmadd.wd(<16 x i16> %a, <16 x i16> %b)
-           ret <8 x i32> %r
-         }
-         attributes #0 = { "target-features"="+avx2" }
-         """, "entry"),
-        NTuple{8,Base.VecElement{Int32}},
-        Tuple{NTuple{16,Base.VecElement{Int16}},NTuple{16,Base.VecElement{Int16}}},
-        a.data, b.data))
+# Per-sample shared carrier wipe (interleaved meas + sin/cos Int8) → (DI, DQ)::Vec{W,Int32}:
+# deinterleave mᵣ/mᵢ, widen to Int32, multiply. Same expressions on every backend (no intrinsic).
+@inline function _wipe(v::Vec{M,Int16}, sinv, cosv) where {M}
+    mr = _wide32(_re(v)); mi = _wide32(_im(v)); cs = _wide32(cosv); sn = _wide32(sinv)
+    (mr * cs + mi * sn, mi * cs - mr * sn)
 end
 
-# W-wide Int16 multiply-add → W/2 Int32 lanes (two pmaddwd over the register halves, concatenated).
-@inline _madd(a::Vec{W,Int16}, b::Vec{W,Int16}) where {W} = shufflevector(
-    _vpmaddwd(_lo(a), _lo(b)), _vpmaddwd(_hi(a), _hi(b)), Val(ntuple(i -> i - 1, Val(W ÷ 2))))
+# Accumulate one chunk into the six Int32 E/P/L accumulators (code ±1/±2 × Int32 DI/DQ).
+@inline _accum_epl(IE, QE, IP, QP, IL, QL, cE, cP, cL, DI, DQ) =
+    (IE + cE * DI, QE + cE * DQ, IP + cP * DI, QP + cP * DQ, IL + cL * DI, QL + cL * DQ)
 
-# Complex pmaddwd accumulation. `v` loads 2W interleaved Int16 (W complex samples); deinterleave
-# to mᵣ/mᵢ (once), form mᵣ·code / mᵢ·code in Int16 (≤ ±4096), then four pmaddwd against the
-# widened carrier accumulate the complex output in Int32:
-#   I += code·(mᵣ·cos + mᵢ·sin),   Q += code·(mᵢ·cos − mᵣ·sin).
-macro _accum_madd!(AI, AQ, v, sinv, cosv, code)
+# ── FUSED E/P/L: one Prompt code lookup per chunk; Early/Late are lane-shifts across a sliding
+# pipeline of P = ⌈D/W⌉+⌊D/W⌋+2 carried code chunks. `@generated` so the pipeline length, the
+# per-correlator chunk indices and the shuffle masks fold to literals (fully unrolled, 0-alloc)
+# for any (W, D). The Prompt code is a single value-based stream; nothing is materialised.
+@generated function correlate_epl_fused(meas::Vector{Int16}, ceng1, reng, ::Val{W}, ::Val{D}) where {W,D}
+    g = cld(D, W); fl = fld(D, W); P = g + fl + 2
+    re = g * W - D; rl = D - fl * W
+    csym = Vector{Symbol}(undef, P); for i in 1:P; csym[i] = Symbol(:c_, i); end
+    em = Vector{Int}(undef, W); for i in 1:W; em[i] = (i - 1) + re; end; emask = Tuple(em)
+    lm = Vector{Int}(undef, W); for i in 1:W; lm[i] = (i - 1) + rl; end; lmask = Tuple(lm)
+    prime = Expr[]                                           # c_1..c_g = 0 (samples < 0); c_{g+1}.. = lookups
+    for i in 1:g; push!(prime, :($(csym[i]) = z)); end
+    for i in g+1:P
+        push!(prime, :($(csym[i]) = code_lookup(ceng1, cs))); push!(prime, :(cs = code_advance(ceng1, cs)))
+    end
+    shift = Expr[]                                           # slide the pipeline left, push the next lookup
+    for i in 1:P-1; push!(shift, :($(csym[i]) = $(csym[i+1]))); end
+    push!(shift, :($(csym[P]) = code_lookup(ceng1, cs))); push!(shift, :(cs = code_advance(ceng1, cs)))
     quote
-        vv = $(esc(v)); cd = _wide16($(esc(code)))
-        mcr = _re(vv) * cd; mci = _im(vv) * cd
-        cs = _wide16($(esc(cosv))); sn = _wide16($(esc(sinv)))
-        $(esc(AI)) += _madd(mcr, cs) + _madd(mci, sn)
-        $(esc(AQ)) += _madd(mci, cs) - _madd(mcr, sn)
+        IE = zero(Vec{$W,Int32}); QE = zero(Vec{$W,Int32}); IP = zero(Vec{$W,Int32})
+        QP = zero(Vec{$W,Int32}); IL = zero(Vec{$W,Int32}); QL = zero(Vec{$W,Int32})
+        cs = code_state(ceng1, 0); rs = carrier_state(reng, 0); z = zero(Vec{$W,Int8})
+        $(prime...)
+        n = 0; lim = length(meas) ÷ 2
+        @inbounds while n < lim
+            sinv, cosv = carrier_lookup(reng, rs); rs = carrier_advance(reng, rs, 1)
+            DI, DQ = _wipe(vload(Vec{$(2W),Int16}, meas, 2n + 1), sinv, cosv)
+            early = shufflevector($(csym[1]), $(csym[2]), Val($emask))
+            late = shufflevector($(csym[g+fl+1]), $(csym[g+fl+2]), Val($lmask))
+            cE = _wide32(early); cP = _wide32($(csym[g+1])); cL = _wide32(late)
+            IE, QE, IP, QP, IL, QL = _accum_epl(IE, QE, IP, QP, IL, QL, cE, cP, cL, DI, DQ)
+            $(shift...)
+            n += $W
+        end
+        ((sum(IE), sum(QE)), (sum(IP), sum(QP)), (sum(IL), sum(QL)))
     end
 end
 
-# Portable complex accumulation (any width): widen everything to Int32 and multiply there —
-# no overflow, no intrinsic. Same I/Q expressions as the pmaddwd path.
-macro _accum_portable!(AI, AQ, v, sinv, cosv, code)
-    quote
-        vv = $(esc(v)); cd = _wide32($(esc(code)))
-        mcr = _wide32(_re(vv)) * cd; mci = _wide32(_im(vv)) * cd
-        cs = _wide32($(esc(cosv))); sn = _wide32($(esc(sinv)))
-        $(esc(AI)) += mcr * cs + mci * sn
-        $(esc(AQ)) += mci * cs - mcr * sn
-    end
-end
-
-# ── FUSED kernels: code × carrier in registers, consumed in place (no array materialised) ──
-# The value-based engines (`code_engine`/`carrier_engine`) are loop-invariant and built once in
-# setup, then passed in: dispatch specialises each kernel on the concrete engine types (a function
-# barrier), so the renew-by-value state stepping stays allocation-free even where the outer
-# inference is abstract. `ceng4`/`ceng1` are the K=4 (4-way interleaved) and K=1 (tail) code
-# engines; `reng` is the single, interleave-agnostic carrier engine (its `carrier_advance` takes
-# an explicit chunk count, so the same engine drives both the 4-way main loop and the 1-wide tail).
-#
-# pmaddwd path (AVX2 W=32 / AVX-512 W=64): Int32 accumulators with halved lane count (W÷2).
-function correlate_fused_madd(meas::Vector{Int16}, ceng4, ceng1, reng, N::Int, ::Val{W}) where {W}
-    AI = zero(Vec{W ÷ 2,Int32}); AQ = zero(Vec{W ÷ 2,Int32})
-    n4 = (N ÷ (4W)) * (4W)
-    # 4-way interleaved main loop: four code/carrier streams W samples apart → carry chains overlap.
-    cs1 = code_state(ceng4, 0); cs2 = code_state(ceng4, 1); cs3 = code_state(ceng4, 2); cs4 = code_state(ceng4, 3)
-    rs1 = carrier_state(reng, 0); rs2 = carrier_state(reng, W); rs3 = carrier_state(reng, 2W); rs4 = carrier_state(reng, 3W)
+# ── UNFUSED E/P/L: materialise the extended Prompt code (samples −D … N−1+D, leading D zero)
+# + the shared carrier, then run the shared-wipe loop with Early/Prompt/Late as offset reads.
+# `ext[k]` holds the code at sample k−1−D, so at output sample n Early/Prompt/Late read
+# ext[n+1] / ext[n+D+1] / ext[n+2D+1]. Generator is warm (continuing); timed region is 0-alloc.
+function correlate_epl_unfused!(ext::Vector{Int8}, csin::Vector{Int8}, ccos::Vector{Int8},
+                                meas::Vector{Int16}, code_gen, tbl, fs, freq, N::Int,
+                                ::Val{W}, ::Val{D}) where {W,D}
+    gen_code!(view(ext, (D + 1):(D + N + D)), code_gen)     # samples 0 … N+D−1 (ext[1:D] stay 0)
+    generate_carrier!(view(csin, 1:N), view(ccos, 1:N), tbl; frequency = freq, sampling_frequency = fs)
+    IE = zero(Vec{W,Int32}); QE = zero(Vec{W,Int32}); IP = zero(Vec{W,Int32})
+    QP = zero(Vec{W,Int32}); IL = zero(Vec{W,Int32}); QL = zero(Vec{W,Int32})
     n = 0
-    @inbounds for _ in 1:(N ÷ (4W))
-        s1, co1 = carrier_lookup(reng, rs1)
-        @_accum_madd! AI AQ vload(Vec{2W,Int16}, meas, 2n + 1)        s1 co1 code_lookup(ceng4, cs1)
-        s2, co2 = carrier_lookup(reng, rs2)
-        @_accum_madd! AI AQ vload(Vec{2W,Int16}, meas, 2(n + W) + 1)  s2 co2 code_lookup(ceng4, cs2)
-        s3, co3 = carrier_lookup(reng, rs3)
-        @_accum_madd! AI AQ vload(Vec{2W,Int16}, meas, 2(n + 2W) + 1) s3 co3 code_lookup(ceng4, cs3)
-        s4, co4 = carrier_lookup(reng, rs4)
-        @_accum_madd! AI AQ vload(Vec{2W,Int16}, meas, 2(n + 3W) + 1) s4 co4 code_lookup(ceng4, cs4)
-        n += 4W
-        cs1 = code_advance(ceng4, cs1); cs2 = code_advance(ceng4, cs2)
-        cs3 = code_advance(ceng4, cs3); cs4 = code_advance(ceng4, cs4)
-        rs1 = carrier_advance(reng, rs1, 4); rs2 = carrier_advance(reng, rs2, 4)
-        rs3 = carrier_advance(reng, rs3, 4); rs4 = carrier_advance(reng, rs4, 4)
-    end
-    # < 4·W tail, single-wide engines positioned at sample n4; sub-W remainder rides on meas's pad.
-    cst = code_state(ceng1, n4 ÷ W); rst = carrier_state(reng, n4)
-    @inbounds while n < length(meas) ÷ 2
-        sv, cosv = carrier_lookup(reng, rst)
-        @_accum_madd! AI AQ vload(Vec{2W,Int16}, meas, 2n + 1) sv cosv code_lookup(ceng1, cst)
+    @inbounds while n < length(csin)
+        DI, DQ = _wipe(vload(Vec{2W,Int16}, meas, 2n + 1),
+                       vload(Vec{W,Int8}, csin, n + 1), vload(Vec{W,Int8}, ccos, n + 1))
+        cE = _wide32(vload(Vec{W,Int8}, ext, n + 1))
+        cP = _wide32(vload(Vec{W,Int8}, ext, n + D + 1))
+        cL = _wide32(vload(Vec{W,Int8}, ext, n + 2D + 1))
+        IE, QE, IP, QP, IL, QL = _accum_epl(IE, QE, IP, QP, IL, QL, cE, cP, cL, DI, DQ)
         n += W
-        cst = code_advance(ceng1, cst); rst = carrier_advance(reng, rst, 1)
     end
-    (sum(AI), sum(AQ))
+    ((sum(IE), sum(QE)), (sum(IP), sum(QP)), (sum(IL), sum(QL)))
 end
 
-# Portable fallback (NEON / scalar): plain Int32 multiply at the backend's width.
-function correlate_fused_portable(meas::Vector{Int16}, ceng4, ceng1, reng, N::Int, ::Val{W}) where {W}
-    AI = zero(Vec{W,Int32}); AQ = zero(Vec{W,Int32})
-    n4 = (N ÷ (4W)) * (4W)
-    cs1 = code_state(ceng4, 0); cs2 = code_state(ceng4, 1); cs3 = code_state(ceng4, 2); cs4 = code_state(ceng4, 3)
-    rs1 = carrier_state(reng, 0); rs2 = carrier_state(reng, W); rs3 = carrier_state(reng, 2W); rs4 = carrier_state(reng, 3W)
-    n = 0
-    @inbounds for _ in 1:(N ÷ (4W))
-        s1, co1 = carrier_lookup(reng, rs1)
-        @_accum_portable! AI AQ vload(Vec{2W,Int16}, meas, 2n + 1)        s1 co1 code_lookup(ceng4, cs1)
-        s2, co2 = carrier_lookup(reng, rs2)
-        @_accum_portable! AI AQ vload(Vec{2W,Int16}, meas, 2(n + W) + 1)  s2 co2 code_lookup(ceng4, cs2)
-        s3, co3 = carrier_lookup(reng, rs3)
-        @_accum_portable! AI AQ vload(Vec{2W,Int16}, meas, 2(n + 2W) + 1) s3 co3 code_lookup(ceng4, cs3)
-        s4, co4 = carrier_lookup(reng, rs4)
-        @_accum_portable! AI AQ vload(Vec{2W,Int16}, meas, 2(n + 3W) + 1) s4 co4 code_lookup(ceng4, cs4)
-        n += 4W
-        cs1 = code_advance(ceng4, cs1); cs2 = code_advance(ceng4, cs2)
-        cs3 = code_advance(ceng4, cs3); cs4 = code_advance(ceng4, cs4)
-        rs1 = carrier_advance(reng, rs1, 4); rs2 = carrier_advance(reng, rs2, 4)
-        rs3 = carrier_advance(reng, rs3, 4); rs4 = carrier_advance(reng, rs4, 4)
-    end
-    cst = code_state(ceng1, n4 ÷ W); rst = carrier_state(reng, n4)
-    @inbounds while n < length(meas) ÷ 2
-        sv, cosv = carrier_lookup(reng, rst)
-        @_accum_portable! AI AQ vload(Vec{2W,Int16}, meas, 2n + 1) sv cosv code_lookup(ceng1, cst)
-        n += W
-        cst = code_advance(ceng1, cst); rst = carrier_advance(reng, rst, 1)
-    end
-    (sum(AI), sum(AQ))
-end
-
-# Build the value-based engines once (a receiver reuses them across integrations): K=4 / K=1 code
-# engines over the plan + the carrier NCO engine. `code_engine`'s parameterless `default_backend()`
-# const-folds to the host backend, so the engine types are concrete and the kernels stay 0-alloc.
-@inline function _fused_engines(plan, tbl, fs, fc, freq)
-    (GNSSSignals.code_engine(plan, fs, fc, Val(4)),
-     GNSSSignals.code_engine(plan, fs, fc, Val(1)),
+# Prompt code engine (a single stream — Early/Late are derived by lane-shift) + carrier engine.
+# Built once and reused. `code_engine`'s parameterless `default_backend()` const-folds to the
+# host backend, so the engine types are concrete and the fused kernel stays 0-alloc.
+@inline _epl_engines(plan, tbl, fs, fc, freq) =
+    (GNSSSignals.code_engine(plan, fs, fc, Val(1)),
      carrier_engine(tbl; frequency = freq, sampling_frequency = fs))
-end
 
-# ── UNFUSED kernels: materialise code + carrier into preallocated buffers, then correlate.
-# The code generator is prebuilt (warm) and reused so the timed region allocates nothing —
-# the comparison is purely register-fusion vs the extra memory passes of materialise-then-read.
-function correlate_unfused_madd!(code::Vector{Int8}, csin::Vector{Int8}, ccos::Vector{Int8},
-                                 meas::Vector{Int16}, code_gen, tbl, fs, freq, N::Int, ::Val{W}) where {W}
-    gen_code!(view(code, 1:N), code_gen)
-    generate_carrier!(view(csin, 1:N), view(ccos, 1:N), tbl; frequency = freq, sampling_frequency = fs)
-    AI = zero(Vec{W ÷ 2,Int32}); AQ = zero(Vec{W ÷ 2,Int32}); n = 0
-    @inbounds while n < length(code)
-        @_accum_madd! AI AQ vload(Vec{2W,Int16}, meas, 2n + 1) vload(Vec{W,Int8}, csin, n + 1) vload(Vec{W,Int8}, ccos, n + 1) vload(Vec{W,Int8}, code, n + 1)
-        n += W
-    end
-    (sum(AI), sum(AQ))
-end
-
-function correlate_unfused_portable!(code::Vector{Int8}, csin::Vector{Int8}, ccos::Vector{Int8},
-                                     meas::Vector{Int16}, code_gen, tbl, fs, freq, N::Int, ::Val{W}) where {W}
-    gen_code!(view(code, 1:N), code_gen)
-    generate_carrier!(view(csin, 1:N), view(ccos, 1:N), tbl; frequency = freq, sampling_frequency = fs)
-    AI = zero(Vec{W,Int32}); AQ = zero(Vec{W,Int32}); n = 0
-    @inbounds while n < length(code)
-        @_accum_portable! AI AQ vload(Vec{2W,Int16}, meas, 2n + 1) vload(Vec{W,Int8}, csin, n + 1) vload(Vec{W,Int8}, ccos, n + 1) vload(Vec{W,Int8}, code, n + 1)
-        n += W
-    end
-    (sum(AI), sum(AQ))
-end
-
-# Register the benchmarks only where the value-based code engine exists (skipped on a
-# baseline without the code-LUT API, so AirspeedVelocity can still diff against it).
+# Register the E/P/L benchmarks only where the value-based code engine exists (skipped on a
+# baseline without the code-LUT API, so AirspeedVelocity can still diff against it). Two rates:
+# 5 MHz (N=5000, D=2; D<W on every backend) and 40 MHz (N=40000, D=20; D>W on NEON).
 if isdefined(GNSSSignals, :code_engine)
-    let
-        fs = 5e6           # 5 MHz sampling
-        fc = 1.023e6       # GPS L1 C/A chip rate
-        freq = 1234.0      # residual carrier / Doppler to wipe off (Hz)
-        N = 5000           # 1 ms at 5 MHz
-        carrier_amplitude = 8   # carrier ∈ ±amplitude (configurable, stored Int8)
-        adc_bits = 12           # measurement is a 12-bit ADC sample, stored Int16
-        plan = GNSSSignals.CodeReplicaLUT(_GPSL1(), 1)
-        code_gen = GNSSSignals.CodeGeneratorLUT(plan, fs, fc)   # warm generator for the unfused fill
-        tbl = SinCosTable(Int8; steps = 64, amplitude = carrier_amplitude)
+    for (label, fs, fc) in (
+        ("GPSL1CA E/P/L 5MHz 1ms", 5e6, 1.023e6),
+        ("GPSL1CA E/P/L 40MHz 1ms", 40e6, 1.023e6),
+    )
+        let
+            freq = 1234.0                              # residual carrier / Doppler to wipe off (Hz)
+            N = round(Int, fs * 1e-3)                  # 1 ms
+            D = round(Int, 0.5 * fs / fc)              # ½-chip Early/Late spacing, in samples
+            carrier_amplitude = 8                      # carrier ∈ ±amplitude (stored Int8)
+            adc_bits = 12                              # measurement is a 12-bit ADC sample (Int16)
+            plan = GNSSSignals.CodeReplicaLUT(_GPSL1(), 1)
+            code_gen = GNSSSignals.CodeGeneratorLUT(plan, fs, fc)   # warm generator for the unfused fill
+            tbl = SinCosTable(Int8; steps = 64, amplitude = carrier_amplitude)
+            ceng1, reng = _epl_engines(plan, tbl, fs, fc, freq)
 
-        # Value-based fused engines, built once (loop-invariant): K=4 + K=1 code engines + carrier.
-        ceng4, ceng1, reng = _fused_engines(plan, tbl, fs, fc, freq)
+            # Zero-pad to a whole number of W-wide chunks (Npad samples). meas is complex with
+            # re/im interleaved → 2·Npad Int16 words. ext spans samples −D … (Npad−1)+D.
+            Npad = cld(N, _CORR_W) * _CORR_W
+            lim = Int16(1) << (adc_bits - 1)                       # 12-bit signed range ±2048
+            meas = zeros(Int16, 2 * Npad)                          # [re₀, im₀, re₁, im₁, …]
+            meas[1:2N] .= rand(-lim:(lim - Int16(1)), 2N)
+            ext = zeros(Int8, Npad + 2D); csin = zeros(Int8, Npad); ccos = zeros(Int8, Npad)
 
-        # Zero-pad to a whole number of W-wide chunks (Npad complex samples) so the fused tail
-        # and the unfused loop never read past the end and the sub-W remainder contributes 0.
-        # The measurement is complex with re/im interleaved, so it holds 2·Npad Int16 words.
-        Npad = cld(N, _CORR_W) * _CORR_W
-        lim = Int16(1) << (adc_bits - 1)                        # 12-bit signed range ±2048
-        meas = zeros(Int16, 2 * Npad)                           # [re₀, im₀, re₁, im₁, …]
-        meas[1:2N] .= rand(-lim:(lim - Int16(1)), 2N)
-        code = zeros(Int8, Npad); csin = zeros(Int8, Npad); ccos = zeros(Int8, Npad)
-
-        g = SUITE["correlation"]["GPSL1CA 5MHz 1ms"]
-        if _HAS_VPMADDWD
-            g["fused"] = @benchmarkable correlate_fused_madd(
-                $meas, $ceng4, $ceng1, $reng, $N, $(Val(_CORR_W)),
+            g = SUITE["correlation"][label]
+            g["fused"] = @benchmarkable correlate_epl_fused(
+                $meas, $ceng1, $reng, $(Val(_CORR_W)), $(Val(D)),
             ) evals = 1 samples = 1000
-            g["unfused"] = @benchmarkable correlate_unfused_madd!(
-                $code, $csin, $ccos, $meas, $code_gen, $tbl, $fs, $freq, $N, $(Val(_CORR_W)),
-            ) evals = 1 samples = 1000
-        else
-            g["fused"] = @benchmarkable correlate_fused_portable(
-                $meas, $ceng4, $ceng1, $reng, $N, $(Val(_CORR_W)),
-            ) evals = 1 samples = 1000
-            g["unfused"] = @benchmarkable correlate_unfused_portable!(
-                $code, $csin, $ccos, $meas, $code_gen, $tbl, $fs, $freq, $N, $(Val(_CORR_W)),
+            g["unfused"] = @benchmarkable correlate_epl_unfused!(
+                $ext, $csin, $ccos, $meas, $code_gen, $tbl, $fs, $freq, $N,
+                $(Val(_CORR_W)), $(Val(D)),
             ) evals = 1 samples = 1000
         end
     end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -6,6 +6,16 @@ using SinCosLUT: SinCosTable, generate_carrier!, cycles_per_sample,
                  carrier_engine, carrier_state, carrier_lookup, carrier_advance, carrier_width
 using Unitful: Hz, ustrip, @u_str
 
+# Polyester is optional: it only backs the parallel multi-channel correlation rows below.
+# Guard the import so the rest of the suite still loads (and diffs against a baseline) on an
+# environment without it. Added to the benchpkg env via the workflow's `--add` list.
+const _HAS_POLYESTER = try
+    @eval import Polyester
+    true
+catch
+    false
+end
+
 # Strip a Unitful frequency to a plain Float64 Hz value (for computing N).
 ustrip_hz(x) = Float64(ustrip(u"Hz", x))
 
@@ -345,6 +355,102 @@ if isdefined(GNSSSignals, :code_engine)
                 $ext, $csin, $ccos, $meas, $code_gen, $tbl, $fs, $freq, $N,
                 $(Val(_CORR_W)), $(Val(D)),
             ) evals = 1 samples = 1000
+        end
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PARALLEL multi-channel correlation — FUSED vs UNFUSED across many satellites (Polyester).
+#
+# This is where the fused/unfused trade-off INVERTS. Per channel (single thread) the fused is
+# execution-port bound and ~10% slower than the unfused (see the single-channel rows above).
+# But the fused materialises NOTHING — it drives the code+carrier engines straight into the
+# correlation, so its only memory traffic is reading the shared measurement. The unfused
+# instead writes a per-channel extended-code + carrier scratch (≈ 3·N Int8 per channel) and
+# reads it back. Run one channel per core and that per-channel scratch — `n_channels · 3 · N`
+# bytes in flight at once — eventually overflows the shared last-level cache and saturates
+# memory bandwidth: the unfused stops scaling with cores while the fused keeps scaling, because
+# it never touches the bus. So the fused WINS once the working set exceeds the LLC.
+#
+# The crossover is therefore governed by `n_channels · 3 · N_samples` vs the LLC size, and the
+# effect only appears with `Threads.nthreads() > 1` (run julia with `-t auto` /
+# `JULIA_NUM_THREADS`). Two representative points at 40 MHz, 10 channels, on a 12-core / 24 MB-L3
+# machine: 5 ms (≈6 MB, fits L3 → fused still ~10% behind) and 20 ms (≈24 MB, spills L3 → fused
+# ~1.2× faster; +47% at 30 ms). At lower sample rates / fewer channels the working set is
+# smaller, so the crossover moves to longer integration.
+#
+# Each channel gets its own PRN, Doppler, code/carrier engines and (unfused) scratch buffers;
+# the measurement is shared. State is bundled in `_EPLChannels` so Polyester sees only a struct
+# and the loop index — it does NOT rewrite the per-channel vectors into stride-arrays (which
+# would not match the kernels' `Vector` signatures). One channel per `@batch` task.
+# ─────────────────────────────────────────────────────────────────────────────
+# Defined unconditionally (a struct must be top level); the drivers/registration that use
+# Polyester's `@batch` are guarded below.
+struct _EPLChannels{W,D,CE,RE,CG,TB}
+    meas::Vector{Int16}
+    cengs::Vector{CE}
+    rengs::Vector{RE}
+    exts::Vector{Vector{Int8}}
+    csins::Vector{Vector{Int8}}
+    ccoss::Vector{Vector{Int8}}
+    code_gens::Vector{CG}
+    tbls::Vector{TB}
+    fs::Float64
+    freqs::Vector{Float64}
+    N::Int
+    out::Vector{Int}     # per-channel sink (prompt I) — prevents dead-code elimination
+end
+
+if _HAS_POLYESTER && isdefined(GNSSSignals, :code_engine)
+    # Build `nch` independent channels (distinct PRN + Doppler) sharing one measurement.
+    function _build_channels(nch::Int, fs, fc, ms)
+        W = _CORR_W
+        N = round(Int, fs * 1e-3 * ms)
+        D = round(Int, 0.5 * fs / fc)
+        Npad = cld(N, W) * W
+        lim = Int16(1) << 11                                   # 12-bit ADC
+        meas = zeros(Int16, 2 * Npad)
+        meas[1:2N] .= rand(-lim:(lim - Int16(1)), 2N)
+        plans = [GNSSSignals.CodeReplicaLUT(_GPSL1(), prn) for prn in 1:nch]
+        freqs = [1234.0 + 137.0 * (s - 1) for s in 1:nch]      # spread the residual Dopplers
+        tbls = [SinCosTable(Int8; steps = 64, amplitude = 8) for _ in 1:nch]
+        engs = [_epl_engines(plans[s], tbls[s], fs, fc, freqs[s]) for s in 1:nch]
+        cengs = [e[1] for e in engs]
+        rengs = [e[2] for e in engs]
+        code_gens = [GNSSSignals.CodeGeneratorLUT(plans[s], fs, fc) for s in 1:nch]
+        exts = [zeros(Int8, Npad + 2D) for _ in 1:nch]
+        csins = [zeros(Int8, Npad) for _ in 1:nch]
+        ccoss = [zeros(Int8, Npad) for _ in 1:nch]
+        ch = _EPLChannels{W,D,eltype(cengs),eltype(rengs),eltype(code_gens),eltype(tbls)}(
+            meas, cengs, rengs, exts, csins, ccoss, code_gens, tbls, Float64(fs), freqs, N,
+            zeros(Int, nch))
+        ch
+    end
+
+    # One channel of work (indexing lives here, not in the `@batch` body, so Polyester leaves
+    # the per-channel vectors as plain `Vector`s).
+    @inline function _epl_one_fused!(ch::_EPLChannels{W,D}, s) where {W,D}
+        @inbounds r = correlate_epl_fused(ch.meas, ch.cengs[s], ch.rengs[s], Val(W), Val(D))
+        @inbounds ch.out[s] = r[2][1]
+        nothing
+    end
+    @inline function _epl_one_unfused!(ch::_EPLChannels{W,D}, s) where {W,D}
+        @inbounds r = correlate_epl_unfused!(ch.exts[s], ch.csins[s], ch.ccoss[s], ch.meas,
+            ch.code_gens[s], ch.tbls[s], ch.fs, ch.freqs[s], ch.N, Val(W), Val(D))
+        @inbounds ch.out[s] = r[2][1]
+        nothing
+    end
+    _epl_fused_par!(ch::_EPLChannels) =
+        (Polyester.@batch for s in eachindex(ch.cengs); _epl_one_fused!(ch, s); end; ch.out)
+    _epl_unfused_par!(ch::_EPLChannels) =
+        (Polyester.@batch for s in eachindex(ch.cengs); _epl_one_unfused!(ch, s); end; ch.out)
+
+    let nch = 10, fs = 40e6, fc = 1.023e6
+        for ms in (5, 20)                              # 5 ms: fits L3; 20 ms: spills L3 (see note)
+            ch = _build_channels(nch, fs, fc, ms)
+            g = SUITE["correlation"]["GPSL1CA E/P/L 40MHz $(nch)ch $(ms)ms ‖"]
+            g["fused"]   = @benchmarkable _epl_fused_par!($ch) evals = 1 samples = 200
+            g["unfused"] = @benchmarkable _epl_unfused_par!($ch) evals = 1 samples = 200
         end
     end
 end


### PR DESCRIPTION
Stacked on #69. Replaces the prompt-only fused/unfused correlation benchmark (added in #77, now part of #69) with the full **Early / Prompt / Late** tracking-correlation path, at two sampling rates.

## Why
A real tracking update runs three correlators (E/P/L), not just Prompt. The three share the same carrier, which changes both the fastest algorithm and the fused-vs-unfused trade-off.

## What changed
- **Shared carrier wipe-off.** The carrier is identical for E/P/L, so the per-sample `DI = mᵣ·cos + mᵢ·sin`, `DQ = mᵢ·cos − mᵣ·sin` is computed **once** (Int32) and each correlator reduces to a cheap `Σ codeₓ·DI` / `Σ codeₓ·DQ`. ~1.8× faster than three independent correlations.
- **Early/Late = Prompt shifted by `D` samples** (½-chip spacing, `D = round(0.5·fs/fc)`). The code is generated **once** (`N+2D` samples) instead of three times, and it **fuses**: the fused kernel looks the Prompt code up once per `W`-wide chunk and derives Early/Late by register lane-shifts across a `@generated` sliding pipeline of `⌈D/W⌉+⌊D/W⌋+2` carried code chunks — allocation-free for any `(W, D)`, handling both `D<W` and `D≥W` (the latter exercised by 40 MHz on NEON). The alternative (generate E/L independently — 3 lookups + advances) is ~20–25 % slower and can't express a sub-chip spacing when fused.
- **Two groups:** `GPSL1CA E/P/L 5MHz 1ms` (N=5000, D=2) and `GPSL1CA E/P/L 40MHz 1ms` (N=40000, D=20).
- **Int32 wipe, not `vpmaddwd`.** The wipe output is per-sample, so `vpmaddwd`'s Int16×Int16→Int32 *pairwise-sum* packing is pure overhead here (~17–25 % slower, measured on AVX-512); `vpmaddwd` only pays off for a reduced sum, which here is the cheap code step. NEON has no `vpmaddwd` anyway. This also removes the `_madd2`/`_ilv`/`_vpmaddwd` machinery.

Fused and unfused are verified **bit-identical** (and against a scalar reference); both are **allocation-free**.

## Measured (AVX-512, W=64)
| group | fused | unfused | allocs |
|:--|--:|--:|--:|
| E/P/L 5 MHz 1 ms (N=5000, D=2) | ~1.55 µs | ~1.39 µs | 0 |
| E/P/L 40 MHz 1 ms (N=40000, D=20) | ~12.1 µs | ~10.5 µs | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)