### PR TITLE
feat(code_lut): support Galileo E1B CBOC via Int8 integer-amplitude LUT

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -120,6 +120,39 @@ for (name, signal, prn, fs, fc) in _LUT_CASES
     end
 end
 
+# ── Galileo E1B full CBOC, head to head — same `code/1 ms integration/GalileoE1B/…` group
+# as the rows above, but special-cased because CBOC differs from the ±1 cases:
+#   • the ORIGINAL `gen_code!` needs a Float32 buffer (the CBOC subcarrier amplitudes are
+#     irrational), whereas the LUT bakes an Int8 integer approximation (default (19,6));
+#   • the LUT plan only supports CBOC on this branch, so the LUT rows are probed and skipped
+#     on a baseline (the PR base #69) that errors on CBOC — the `original` row still compares.
+# fs ≥ fc·subchip_factor = 12·1.023 MHz; use 15 MHz (matches the legacy E1B row).
+const _LUT_CBOC_OK = isdefined(GNSSSignals, :CodeReplicaLUT) && try
+    GNSSSignals.CodeReplicaLUT(GalileoE1B(), 1)   # CBOC supported here, errors on the baseline
+    true
+catch
+    false
+end
+let signal = GalileoE1B(), prn = 1, fs = 15e6Hz, fc = 1023e3Hz
+    N = round(Int, ustrip_hz(fs) * 1e-3)
+    g = SUITE["code"]["1 ms integration"]["GalileoE1B"]
+    out_f32 = zeros(Float32, N)
+    g["original"] = @benchmarkable gen_code!(
+        $out_f32, $signal, $prn, $fs, $fc, $0.0, $0,
+    ) evals = 10 samples = 1000
+    if _LUT_CBOC_OK
+        gen = GNSSSignals.CodeGeneratorLUT(GNSSSignals.CodeReplicaLUT(signal, prn), fs, fc)
+        out8g = zeros(Int8, N)
+        g["LUT generator"] = @benchmarkable gen_code!($out8g, $gen) evals = 10 samples = 1000
+
+        plan = GNSSSignals.CodeReplicaLUT(signal, prn)
+        out8 = zeros(Int8, N)
+        g["LUT one-shot"] = @benchmarkable gen_code!(
+            $out8, $plan, $fs, $fc, $0.0, $0,
+        ) evals = 10 samples = 1000
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Threaded multi-channel: build a Vector{CodeReplicaLUT} for 8 PRNs once, then
 # time filling 8 per-channel buffers in parallel with `Threads.@threads`. The

--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -13,16 +13,17 @@
 # / AVX2 `vpshufb` sliding-window permute over a drift-free integer DDA — or, once the
 # baked table is heavily oversampled (so consecutive samples repeat a chip), a broadcast
 # run-fill that matches the original `gen_code!`'s store-bound speed instead of paying a
-# permute per window. It is Int8/±1 only (no CBOC / cosine-BOC) and requires sub-chip
-# oversampling (`sampling_frequency ≥ code_frequency · subchip_factor`).
+# permute per window. The baked table is Int8: ±1 for BPSK/BOC/TMBOC, or a multi-level
+# integer approximation of the sqrt-power amplitudes for CBOC (Galileo E1B); cosine-BOC is
+# unsupported. Requires sub-chip oversampling (`sampling_frequency ≥ code_frequency · subchip_factor`).
 # ─────────────────────────────────────────────────────────────────────────────
 
 # `GNSSSignals.CodeLUT` — internal submodule vendoring the GNSSSignalsLUT.jl SIMD code
 # resampler. Not exported and not part of the public GNSSSignals API; use `CodeReplicaLUT`
 # with `gen_code!` / `gen_code` instead. All names (`CodeTable`, `LOC`, `BOC`, `TMBOC`,
-# `ModulatedCode`, `code_replica`, `generate_code!`, `generate_code`, `AVX512`, `AVX2`,
+# `CBOC`, `ModulatedCode`, `code_replica`, `generate_code!`, `generate_code`, `AVX512`, `AVX2`,
 # `Portable`, `default_backend`, …) live inside this submodule so they do not clash with
-# GNSSSignals' own `LOC` / `BOC` / `TMBOC` / `Modulation`. (Plain comment, not a docstring,
+# GNSSSignals' own `LOC` / `BOC` / `TMBOC` / `CBOC` / `Modulation`. (Plain comment, not a docstring,
 # so Documenter's checkdocs doesn't require this internal module in the manual.)
 module CodeLUT
 
@@ -116,8 +117,11 @@ const _GEN_CODE_LUT_SCRATCH = Dict{Int,Vector{Int8}}()
 @inline _to_hz(x::Frequency) = Float64(ustrip(u"Hz", x))
 @inline _to_hz(x) = Float64(x)
 
-# Map a GNSSSignals modulation to a CodeLUT modulation (Int8/±1 only). Errors on
-# unsupported modulations (CBOC, cosine BOC, code-factor n ≠ 1).
+# Map a GNSSSignals modulation to a CodeLUT modulation. ±1 for LOC/BOC/TMBOC; CBOC bakes a
+# multi-level Int8 integer approximation of its sqrt-power amplitudes (`cboc_amplitudes`).
+# Errors on cosine BOC and code-factor n ≠ 1. The `cboc_amplitudes` argument is ignored by
+# every modulation except CBOC (the generic two-arg method below forwards to the one-arg form).
+_codelut_modulation(m, ::Tuple{Integer,Integer}) = _codelut_modulation(m)
 function _codelut_modulation(m::LOC)
     CodeLUT.LOC()
 end
@@ -130,18 +134,25 @@ function _codelut_modulation(m::TMBOC)
         error("CodeReplicaLUT supports only TMBOC with BOC(1,1) base and code-factor n==1; use gen_code!")
     CodeLUT.TMBOC(Int(m.boc2.m), collect(Bool, m.pattern))
 end
-function _codelut_modulation(m::CBOC)
-    error("CodeReplicaLUT does not support CBOC (Int8/±1 only); use gen_code!")
+function _codelut_modulation(m::CBOC, cboc_amplitudes::Tuple{Integer,Integer})
+    (m.boc1.n == 1 && m.boc2.n == 1) ||
+        error("CodeReplicaLUT supports only code-factor n==1 CBOC; use gen_code!")
+    a1, a2 = cboc_amplitudes
+    (a1 > 0 && a2 > 0) ||
+        error("CodeReplicaLUT cboc_amplitudes must be positive integers; got $cboc_amplitudes")
+    Int(a1) + Int(a2) <= typemax(Int8) ||
+        error("CodeReplicaLUT cboc_amplitudes must satisfy a1 + a2 ≤ $(typemax(Int8)) (Int8 table); got $cboc_amplitudes")
+    CodeLUT.CBOC(Int(m.boc1.m), Int(m.boc2.m), Int8(a1), Int8(a2))
 end
 function _codelut_modulation(m::BOCcos)
     error("CodeReplicaLUT does not support cosine-phased BOC (Int8/±1 only); use gen_code!")
 end
 
 """
-    CodeReplicaLUT(signal::AbstractGNSSSignal, prn::Integer)
+    CodeReplicaLUT(signal::AbstractGNSSSignal, prn::Integer; cboc_amplitudes = (19, 6))
 
 A reusable, rate-independent plan for fast LUT-based code generation of
-`signal`/`prn`. Building it bakes the fully-modulated ±1 replica (primary ×
+`signal`/`prn`. Building it bakes the fully-modulated replica (primary ×
 subcarrier × short secondary) into an expanded `Int8` `CodeTable` once — this is
 the expensive step. The resulting plan is **immutable and read-only**, so it can
 be shared across threads (build once per `(signal, prn)`, reuse it for every
@@ -151,9 +162,25 @@ Pass the plan to [`gen_code!`](@ref) or [`CodeGeneratorLUT`](@ref) with a sampli
 frequency to resample it. The baked table is independent of the sampling and code
 frequency, so a single plan serves any rate.
 
+# CBOC (Galileo E1B)
+CBOC signals are supported via an **Int8 integer approximation** of the two
+sqrt-power subcarrier amplitudes. `cboc_amplitudes = (a1, a2)` sets the integer
+amplitudes of the `BOC(1,1)` and `BOC(6,1)` components respectively; the baked
+sub-chip values are the composite `±(a1 ± a2)`. For a correlation replica only the
+*ratio* `a1/a2` matters (overall scale is irrelevant): the subcarrier correlation
+is exactly the dot product of the amplitude vectors, so the match to the float
+spec is the cosine between `(a1, a2)` and the true `(sqrt(10/11), sqrt(1/11)) ∝
+(sqrt(10), 1) = (3.162, 1)`. The default `(19, 6)` (ratio `3.167`, baked values
+`±25, ±13`) reproduces the float subcarrier to ~0 dB correlation loss; coarser
+choices trade accuracy for smaller magnitudes (`(3, 1)` → −0.001 dB; `(2, 1)` →
+−0.108 dB). Any `a1, a2 > 0` with `a1 + a2 ≤ 127` is accepted. Because the
+amplitudes only scale the replica, the **sign pattern is identical to the float
+`gen_code!`** for any `a1 > a2 > 0`. The argument is ignored for non-CBOC signals.
+
 # Limitations (vs the plain-`signal` `gen_code!`)
-- **Int8 / ±1 only.** CBOC and cosine-phased BOC raise an error at construction
-  (use `gen_code!` with the signal directly).
+- **Int8 output.** Non-CBOC signals are ±1; CBOC is the multi-level integer
+  approximation above. Cosine-phased BOC raises an error at construction (use
+  `gen_code!` with the signal directly).
 - **Sub-chip oversampling required:** `sampling_frequency ≥
   code_frequency · subchip_factor` (else `gen_code!` raises an error).
 - **Integer-chip phase only:** `start_phase` + the `start_index_shift`
@@ -174,8 +201,9 @@ struct CodeReplicaLUT{S<:AbstractGNSSSignal}
     mc::CodeLUT.ModulatedCode   # rate-INDEPENDENT expanded ±1 table, built once
 end
 
-function CodeReplicaLUT(signal::AbstractGNSSSignal, prn::Integer)
-    modulation = _codelut_modulation(get_modulation(signal))
+function CodeReplicaLUT(signal::AbstractGNSSSignal, prn::Integer;
+                       cboc_amplitudes::Tuple{Integer,Integer} = (19, 6))
+    modulation = _codelut_modulation(get_modulation(signal), cboc_amplitudes)
     Lp = get_code_length(signal)
     primary = Int8[get_code_at_index(signal, i, prn) for i in 0:Lp-1]
     sec = get_secondary_code(signal)

--- a/src/code_lut/modulation.jl
+++ b/src/code_lut/modulation.jl
@@ -11,6 +11,13 @@
 #   BOC(m,1) sin: P = 2m, sub-chip k sign = iseven(k) ? +1 : -1
 #   TMBOC(m2):    P = 2·m2, BOC(1,1) at most chip positions, BOC(m2,1) at `pattern`
 #                 positions (the high-rate component sets the resolution)
+#   CBOC(m1,m2):  P = 2·lcm(m1,m2), sub-chip value = a1·BOC(m1,1) ± a2·BOC(m2,1) — a multi-
+#                 level *integer approximation* (e.g. ±(a1±a2)) of the irrational
+#                 sqrt-power CBOC amplitudes. The expanded table holds those Int8 values
+#                 verbatim; the permute/run-fill backends are value-agnostic (they gather
+#                 chips by position, not by value), so the ±1 machinery resamples them
+#                 unchanged. Galileo E1B is CBOC(1,6); the default (a1,a2)=(19,6) ≈
+#                 (sqrt(10/11), sqrt(1/11)) (ratio 3.167 ≈ √10) and the caller may pick another.
 #
 # Resample at `chip_frequency · P` (the sub-chip rate); this needs `fs ≥ chip_frequency·P`
 # (sub-chip oversampling ≥ 1), the same window-span condition as the plain code.
@@ -30,12 +37,23 @@ struct TMBOC <: Modulation                      # BOC(1,1) + BOC(m2,1) at `patte
     m2::Int
     pattern::Vector{Bool}                       # pattern[(pos mod end)+1] == true → use BOC(m2,1)
 end
+# Composite BOC: a1·BOC(m1,1) + a2·BOC(m2,1) with *integer* amplitudes (an Int8 approximation
+# of the irrational sqrt-power CBOC amplitudes). Galileo E1B is CBOC(m1=1, m2=6); the default
+# (a1,a2)=(19,6) approximates (sqrt(10/11), sqrt(1/11)) (ratio 3.167 ≈ √10).
+struct CBOC <: Modulation
+    m1::Int
+    m2::Int
+    a1::Int8                                    # amplitude of the BOC(m1,1) component
+    a2::Int8                                    # amplitude of the BOC(m2,1) component
+end
 
 subchip_factor(::LOC)   = 1
 subchip_factor(b::BOC)  = 2 * b.m
 subchip_factor(t::TMBOC) = 2 * t.m2
+subchip_factor(c::CBOC) = 2 * lcm(c.m1, c.m2)
 
-# Sub-carrier sign for sub-chip `k` (0-based) of a chip at primary position `pos`, given P.
+# Sub-carrier value for sub-chip `k` (0-based) of a chip at primary position `pos`, given P.
+# ±1 for BPSK/BOC/TMBOC; a multi-level integer for CBOC (see below).
 @inline _sc_sign(::LOC, k, pos, P)  = Int8(1)
 @inline _sc_sign(b::BOC, k, pos, P) = iseven(k) ? Int8(1) : Int8(-1)
 @inline function _sc_sign(t::TMBOC, k, pos, P)
@@ -44,6 +62,15 @@ subchip_factor(t::TMBOC) = 2 * t.m2
     else                                                       # BOC(1,1): +1 first half, -1 second
         k < P ÷ 2 ? Int8(1) : Int8(-1)
     end
+end
+# CBOC returns the composite *value* a1·b1 + a2·b2 (e.g. ±(a1±a2)), not a bare sign — the Int8
+# table carries it verbatim. `div(k·2m, P)` is the BOC(m,1) sub-carrier half-period index at the
+# composite resolution P, mirroring the float `get_subcarrier_code`'s `floor(phase·2m)` so the
+# sign at every sub-chip matches the spec (`a1 > a2 > 0` ⇒ same sign as the sqrt-power version).
+@inline function _sc_sign(c::CBOC, k, pos, P)
+    b1 = iseven(div(k * 2 * c.m1, P)) ? Int8(1) : Int8(-1)
+    b2 = iseven(div(k * 2 * c.m2, P)) ? Int8(1) : Int8(-1)
+    c.a1 * b1 + c.a2 * b2
 end
 
 """
@@ -68,7 +95,10 @@ Base.length(mc::ModulatedCode) = length(mc.table)
     code_replica(primary_chips, modulation; secondary=Int8[1], max_bake=typemax(Int16))
 
 Build a [`ModulatedCode`](@ref) from a primary ±1 `primary_chips` vector and a
-`modulation` (`LOC()`, `BOC(m)`, or `TMBOC(m2, pattern)`). `secondary` is a ±1 overlay
+`modulation` (`LOC()`, `BOC(m)`, `TMBOC(m2, pattern)`, or `CBOC(m1, m2, a1, a2)`). The
+table is ±1 for the first three; for `CBOC` it holds the multi-level integer composite
+`a1·BOC(m1,1) ± a2·BOC(m2,1)` (still Int8, so all backends resample it unchanged).
+`secondary` is a ±1 overlay
 that multiplies whole primary periods; it is baked into the table when
 `length(secondary)·length(primary)·subchip_factor ≤ max_bake`, otherwise applied per
 period (a cheap range-negate) at generation time.

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -237,7 +237,8 @@ const _BACKENDS = (CL.Portable(),
         end
         rng = MersenneTwister(2)
         Lp = 31
-        mods = [CL.LOC(), CL.BOC(1), CL.BOC(2), CL.TMBOC(3, [k in (0, 4, 6) for k in 0:10])]
+        mods = [CL.LOC(), CL.BOC(1), CL.BOC(2), CL.TMBOC(3, [k in (0, 4, 6) for k in 0:10]),
+                CL.CBOC(1, 6, Int8(19), Int8(6))]   # multi-level table (values ±25, ±13)
         for modulation in mods, Ls in (1, 4), (a, b) in ((1, 1), (3, 5), (7, 9))
             P = CL.subchip_factor(modulation)
             primary = rand(rng, Int8[-1, 1], Lp)
@@ -316,7 +317,7 @@ end
     # Baked-secondary signals only. Excluded: GPSL5I (non-baked NH10) and GPSL1C_P
     # (its 1800-chip overlay is too long to bake) — both yield a residual secondary
     # and are covered by the error testset below.
-    sigs = [GPSL1CA(), GPSL1C_D(), GalileoE1B_BOC11()]
+    sigs = [GPSL1CA(), GPSL1C_D(), GalileoE1B_BOC11(), GalileoE1B()]   # E1B: CBOC, multi-level long table
     for signal in sigs
         plan = CodeReplicaLUT(signal, 1)
         P = plan.mc.subchip_factor
@@ -432,5 +433,97 @@ end
             end
             @test got == oneshot
         end
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Galileo E1B CBOC support in the LUT path. The subcarrier's two sqrt-power amplitudes are
+# baked as an Int8 *integer approximation* (default (19,6) ≈ (√(10/11), √(1/11)), ratio √10);
+# the permute/run-fill backends carry the resulting multi-level Int8 values verbatim, so the
+# resampled replica reproduces the float `gen_code!` (identical signs; correlation set by the
+# amplitude ratio). `cboc_amplitudes` lets the caller trade accuracy for smaller magnitudes.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "Galileo E1B CBOC (LUT integer approximation)" begin
+    signal = GalileoE1B(); prn = 1
+    fc = get_code_frequency(signal)
+    P = 12                                            # 2·lcm(1,6)
+
+    @testset "plan construction + baked composite values" begin
+        plan = CodeReplicaLUT(signal, prn)           # default (19,6)
+        @test plan.mc.subchip_factor == P
+        @test length(plan.mc.table) == get_code_length(signal) * P
+        @test sort(unique(plan.mc.table.chips)) == Int8[-25, -13, 13, 25]   # ±(19±6)
+        # the documented default really is (19,6)
+        explicit = CodeReplicaLUT(signal, prn; cboc_amplitudes = (19, 6))
+        @test plan.mc.table.chips == explicit.mc.table.chips
+    end
+
+    @testset "custom amplitudes scale the table; sign pattern is amplitude-independent" begin
+        base = CodeReplicaLUT(signal, prn)
+        for (amps, vals) in (((2, 1), Int8[-3, -1, 1, 3]), ((3, 1), Int8[-4, -2, 2, 4]))
+            plan = CodeReplicaLUT(signal, prn; cboc_amplitudes = amps)
+            @test sort(unique(plan.mc.table.chips)) == vals
+            @test sign.(plan.mc.table.chips) == sign.(base.mc.table.chips)
+        end
+    end
+
+    @testset "amplitude validation" begin
+        for bad in ((0, 1), (1, 0), (-1, 1), (1, -2), (100, 100))   # non-positive or a1+a2 > 127
+            @test_throws ErrorException CodeReplicaLUT(signal, prn; cboc_amplitudes = bad)
+        end
+    end
+
+    @testset "matches float gen_code! (signs exact; correlation tracks the amplitude ratio)" begin
+        # At fs = fc·P (integer ratio P) every sample is exactly one sub-chip, so the LUT and
+        # the float path align sub-chip-for-sub-chip: the sign pattern is identical for ALL
+        # amplitudes, and the normalized correlation equals the cosine between (a1,a2) and the
+        # float (√10, 1) — ~1 for (19,6), degrading gracefully for coarser ratios.
+        fs = fc * P
+        N = get_code_length(signal) * P              # one full code period
+        flt = Vector{Float32}(undef, N); gen_code!(flt, signal, prn, fs, fc)
+        for (amps, mincorr) in (((19, 6), 0.9999), ((3, 1), 0.9998), ((2, 1), 0.987))
+            plan = CodeReplicaLUT(signal, prn; cboc_amplitudes = amps)
+            lut = Vector{Int8}(undef, N); gen_code!(lut, plan, fs, fc)
+            @test sign.(lut) == Int8.(sign.(flt))    # signs identical to the spec
+            rho = sum(Float64.(lut) .* flt) /
+                  (sqrt(sum(abs2, Float64.(lut))) * sqrt(sum(abs2, flt)))
+            @test rho >= mincorr
+        end
+    end
+
+    @testset "resampling all backends == fixed-point reference (multi-level table)" begin
+        plan = CodeReplicaLUT(signal, prn)           # default (19,6) → ±25, ±13
+        full = plan.mc.table.chips; Lf = length(full)
+        for (a, b) in ((1, 1), (3, 5), (7, 9)), phase in (0, 7)
+            sn = _step_num(a / b); psub = phase * P; n = 4 * 64 * 8
+            ref = [full[mod(div(sn * (i - 1), _SD) + psub, Lf) + 1] for i in 1:n]
+            for be in _BACKENDS                       # E1B table > typemax(Int16): AVX2/NEON use Int32 phase
+                out = Vector{Int8}(undef, n)
+                CL.generate_code!(out, plan.mc; code_frequency = a, sampling_frequency = b * P,
+                                  phase = phase, backend = be)
+                @test out == ref
+            end
+        end
+    end
+
+    @testset "high-oversampling run-fill: one-shot == warm == chunked (multi-level)" begin
+        plan = CodeReplicaLUT(signal, prn)
+        fs = fc * P * 10                              # broadcast run-fill regime
+        N = 9000
+        oneshot = Vector{Int8}(undef, N); gen_code!(oneshot, plan, fs, fc)
+        gen = CodeGeneratorLUT(plan, fs, fc)
+        warm = Vector{Int8}(undef, N); gen_code!(warm, gen)
+        @test warm == oneshot
+        gen2 = CodeGeneratorLUT(plan, fs, fc); got = Int8[]
+        for chunk in (1, 999, 64, 4096, N - 1 - 999 - 64 - 4096)
+            buf = Vector{Int8}(undef, chunk); gen_code!(buf, gen2); append!(got, buf)
+        end
+        @test got == oneshot
+        @test all(in((-25, -13, 13, 25)), oneshot)   # run-fill preserves the multi-level values
+    end
+
+    @testset "fs < fc·subchip_factor errors" begin
+        plan = CodeReplicaLUT(signal, prn)
+        @test_throws ErrorException gen_code!(Vector{Int8}(undef, 64), plan, fc * (P - 1), fc)
     end
 end


### PR DESCRIPTION
Stacks on #69. Adds Galileo E1B (CBOC) support to the `CodeReplicaLUT` LUT resampler.

## Why this is small
The LUT permute/run-fill backends gather `Int8` chip values **by position** and never assume ±1 — `vpermb`/`vpshufb`/`tbl1`/run-fill all just move bytes. So the `Int8/±1 only` restriction was purely an artifact of the bake step (`_sc_sign`) emitting only ±1. CBOC support is therefore just: bake the **multi-level composite value** `a1·BOC(1,1) ± a2·BOC(6,1)` into the same `Int8` table. Every backend resamples it unchanged.

## API
```julia
plan = CodeReplicaLUT(GalileoE1B(), prn)                       # default cboc_amplitudes = (19, 6)
plan = CodeReplicaLUT(GalileoE1B(), prn; cboc_amplitudes=(3,1)) # caller-tunable accuracy/magnitude
gen_code!(out, plan, fs, fc)                                   # Int8 out; fs ≥ fc·12 (=12.276 MHz)
```
The CBOC subcarrier has two sqrt-power amplitudes (`√(10/11)`, `√(1/11)` for E1B), approximated as integers. For a correlation replica only the **ratio** matters: the subcarrier correlation is exactly the dot product of the amplitude vectors, so the match to the float spec is the cosine between `(a1,a2)` and the true `(√10, 1)`.

| amplitudes | baked values | corr. loss vs float |
|---|---|---|
| `(2,1)` | ±3, ±1 | −0.108 dB |
| `(3,1)` | ±4, ±2 | −0.001 dB |
| **`(19,6)` (default)** | **±25, ±13** | **~0 dB** |

The **sign pattern is identical to the float `gen_code!`** for any `a1 > a2 > 0`. Cosine-phased BOC still errors at construction. The kwarg is ignored for non-CBOC signals.

## Verification vs float `gen_code!`
- Sign agreement: **100%** across PRNs / rates / amplitudes.
- Correlation with the float replica: `(19,6)` → ρ=1.0, `(3,1)` → 0.99988, `(2,1)` → 0.9876 — exactly the predicted cosines.
- Acquisition peak (integer LUT replica × float replica, full code period) = **1.0** at zero lag.

## Performance (Zen-class x86, 1 ms @ 15 MHz)
| | output | min time |
|---|---|---|
| original (float `gen_code!`) | Float32 | 1.46 µs |
| LUT generator (warm) | Int8 | 0.56 µs |
| LUT one-shot | Int8 | 0.61 µs |

~2.6× faster, and Int8 instead of Float32.

## Changes
- `src/code_lut/modulation.jl` — `CBOC(m1,m2,a1,a2)` descriptor (`subchip_factor = 2·lcm`), multi-level `_sc_sign`.
- `src/code_lut.jl` — `CodeReplicaLUT(...; cboc_amplitudes=(19,6))`, amplitude validation, docstrings/comments.
- `test/code_lut.jl` — CBOC added to the all-backend baking test; `GalileoE1B()` added to the value-based engine coverage (CBOC + long Int32-phase table); dedicated 41-test E1B testset.
- `benchmark/benchmarks.jl` — E1B full-CBOC 1 ms head-to-head (float original vs LUT generator/one-shot), guarded so the script still loads against the #69 baseline that errors on CBOC.

## Tests
Full suite green (incl. Aqua): CodeLUT 1068, code_engine 40, **E1B CBOC 41**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)