### PR TITLE
perf(code_lut): tune AVX-512 run-fill threshold (N-aware crossover)

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -226,6 +226,29 @@ if isdefined(GNSSSignals, :CodeGeneratorLUT)
     end
 end
 
+# ── NEON run-fill crossover probe (Apple Silicon only) ────────────────────────────────
+# The NEON crossover can't be measured on the x86 CI box (x86 can't emit NEON), so probe the
+# two kernels directly on the macos-14 runner: time the windowed permute vs the broadcast
+# run-fill at several m, so the NEON crossover can be read off the table and the threshold
+# (currently 3) confirmed/retuned. Gated to NEON hosts — forcing the Neon kernel on x86 would
+# fail to compile — so these keys appear only in the Apple-Silicon results. Base and head call
+# identical kernels here, so both columns report the same NEON times (we want the absolutes).
+if isdefined(GNSSSignals, :CodeGeneratorLUT) &&
+   GNSSSignals.CodeLUT.default_backend() isa GNSSSignals.CodeLUT.Neon
+    let SD = GNSSSignals.CodeLUT._STEP_DEN, be = GNSSSignals.CodeLUT.Neon()
+        tbl = GNSSSignals.CodeReplicaLUT(_GPSL1(), 1).mc.table
+        for m in (2, 3, 4, 5), (slabel, n) in (("512", 512), ("8k", 8192))
+            sn = SD ÷ m
+            o = zeros(Int8, n)
+            grp = SUITE["code"]["neon crossover probe"]["$(lpad(m, 2, '0'))x"][slabel]
+            grp["permute"] =
+                @benchmarkable GNSSSignals.CodeLUT._generate!($o, $tbl, $sn, $SD, 0, $be) evals = 1 samples = 500
+            grp["runfill"] =
+                @benchmarkable GNSSSignals.CodeLUT._generate_runfill!($o, $tbl, $sn, $SD, 0) evals = 1 samples = 500
+        end
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Correlation signal path — FUSED vs UNFUSED, full Early / Prompt / Late (E/P/L).
 #

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -179,7 +179,7 @@ end
 # adjacent. Same N + fs/fc for both, and the LUT side uses the warm generator (0-alloc),
 # matching the original's 0-alloc fill. The LUT uses the windowed permute (flat in the
 # oversampling ratio) at low oversampling and switches to a broadcast run-fill once the
-# baked table is oversampled ≳8× (AVX-512) / ≳4× (AVX2), so it tracks the original's
+# baked table is oversampled ≳7× (AVX-512) / ≳4× (AVX2), so it tracks the original's
 # run-fill speed-up at high oversampling instead of staying flat. It still wins outright at
 # low oversampling and for modulated signals (baked subcarrier).
 # Two representative signals (BPSK + BOC(1,1)); both at fc = 1.023 MHz.

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -207,6 +207,25 @@ let fc = 1023e3Hz
     end
 end
 
+# ── Run-fill threshold crossover sweep (validates the permute↔run-fill selection) ──────
+# The coarse sweep above (2/8/32×) straddles but never lands in the crossover region, so a
+# threshold retune produces no visible diff there. This dense sweep hits the exact (m, N)
+# cells where the per-backend run-fill threshold flips which kernel runs — m around the
+# measured crossovers (3 for AVX2/NEON, 5–7 for AVX-512) at short and long fills (the
+# short ones exercise the AVX-512 N-aware step). GPS L1 C/A has subchip_factor P = 1, so
+# m = oversampling exactly. LUT only — the threshold is internal to the LUT path.
+if isdefined(GNSSSignals, :CodeGeneratorLUT)
+    let fc = 1023e3Hz, signal = _GPSL1(), prn = 1
+        for m in (3, 5, 6, 7), (slabel, n) in (("512", 512), ("2k", 2048), ("64k", 65536))
+            fs = m * fc
+            gen = GNSSSignals.CodeGeneratorLUT(GNSSSignals.CodeReplicaLUT(signal, prn), fs, fc)
+            o8 = zeros(Int8, n)
+            SUITE["code"]["runfill crossover"]["$(lpad(m, 2, '0'))x"][slabel] =
+                @benchmarkable gen_code!($o8, $gen) evals = 1 samples = 500
+        end
+    end
+end
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Correlation signal path — FUSED vs UNFUSED, full Early / Prompt / Late (E/P/L).
 #

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -207,54 +207,6 @@ let fc = 1023e3Hz
     end
 end
 
-# ── Run-fill threshold crossover sweep (validates the permute↔run-fill selection) ──────
-# The coarse sweep above (2/8/32×) straddles but never lands in the crossover region, so a
-# threshold retune produces no visible diff there. This dense sweep hits the exact (m, N)
-# cells where the per-backend run-fill threshold flips which kernel runs — m around the
-# measured crossovers (3 for AVX2/NEON, 5–7 for AVX-512) at short and long fills (the
-# short ones exercise the AVX-512 N-aware step). GPS L1 C/A has subchip_factor P = 1, so
-# m = oversampling exactly. LUT only — the threshold is internal to the LUT path.
-if isdefined(GNSSSignals, :CodeGeneratorLUT)
-    let fc = 1023e3Hz, signal = _GPSL1(), prn = 1
-        plan = GNSSSignals.CodeReplicaLUT(signal, prn)
-        for m in (3, 5, 6, 7), (slabel, n) in (("512", 512), ("2k", 2048), ("64k", 65536))
-            fs = m * fc
-            o8 = zeros(Int8, n)
-            grp = SUITE["code"]["runfill crossover"]["$(lpad(m, 2, '0'))x"][slabel]
-            # One-shot fill: N-aware threshold (it knows length(out)). Shows the AVX-512 N-aware
-            # win at m=5,6 short N, the steady 8→7 at m=7, and AVX2 at m=3.
-            grp["one-shot"] = @benchmarkable gen_code!($o8, $plan, $fs, $fc) evals = 1 samples = 500
-            # Continuing generator: steady-state threshold (kernel fixed at construction, no per-
-            # fill N). Shows the steady 8→7 at m=7; correctly *unchanged* at m=5,6 short N.
-            gen = GNSSSignals.CodeGeneratorLUT(plan, fs, fc)
-            grp["generator"] = @benchmarkable gen_code!($o8, $gen) evals = 1 samples = 500
-        end
-    end
-end
-
-# ── NEON run-fill crossover probe (Apple Silicon only) ────────────────────────────────
-# The NEON crossover can't be measured on the x86 CI box (x86 can't emit NEON), so probe the
-# two kernels directly on the macos-14 runner: time the windowed permute vs the broadcast
-# run-fill at several m, so the NEON crossover can be read off the table and the threshold
-# (currently 3) confirmed/retuned. Gated to NEON hosts — forcing the Neon kernel on x86 would
-# fail to compile — so these keys appear only in the Apple-Silicon results. Base and head call
-# identical kernels here, so both columns report the same NEON times (we want the absolutes).
-if isdefined(GNSSSignals, :CodeGeneratorLUT) &&
-   GNSSSignals.CodeLUT.default_backend() isa GNSSSignals.CodeLUT.Neon
-    let SD = GNSSSignals.CodeLUT._STEP_DEN, be = GNSSSignals.CodeLUT.Neon()
-        tbl = GNSSSignals.CodeReplicaLUT(_GPSL1(), 1).mc.table
-        for m in (2, 3, 4, 5), (slabel, n) in (("512", 512), ("8k", 8192))
-            sn = SD ÷ m
-            o = zeros(Int8, n)
-            grp = SUITE["code"]["neon crossover probe"]["$(lpad(m, 2, '0'))x"][slabel]
-            grp["permute"] =
-                @benchmarkable GNSSSignals.CodeLUT._generate!($o, $tbl, $sn, $SD, 0, $be) evals = 1 samples = 500
-            grp["runfill"] =
-                @benchmarkable GNSSSignals.CodeLUT._generate_runfill!($o, $tbl, $sn, $SD, 0) evals = 1 samples = 500
-        end
-    end
-end
-
 # ─────────────────────────────────────────────────────────────────────────────
 # Correlation signal path — FUSED vs UNFUSED, full Early / Prompt / Late (E/P/L).
 #

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -216,12 +216,18 @@ end
 # m = oversampling exactly. LUT only — the threshold is internal to the LUT path.
 if isdefined(GNSSSignals, :CodeGeneratorLUT)
     let fc = 1023e3Hz, signal = _GPSL1(), prn = 1
+        plan = GNSSSignals.CodeReplicaLUT(signal, prn)
         for m in (3, 5, 6, 7), (slabel, n) in (("512", 512), ("2k", 2048), ("64k", 65536))
             fs = m * fc
-            gen = GNSSSignals.CodeGeneratorLUT(GNSSSignals.CodeReplicaLUT(signal, prn), fs, fc)
             o8 = zeros(Int8, n)
-            SUITE["code"]["runfill crossover"]["$(lpad(m, 2, '0'))x"][slabel] =
-                @benchmarkable gen_code!($o8, $gen) evals = 1 samples = 500
+            grp = SUITE["code"]["runfill crossover"]["$(lpad(m, 2, '0'))x"][slabel]
+            # One-shot fill: N-aware threshold (it knows length(out)). Shows the AVX-512 N-aware
+            # win at m=5,6 short N, the steady 8→7 at m=7, and AVX2 at m=3.
+            grp["one-shot"] = @benchmarkable gen_code!($o8, $plan, $fs, $fc) evals = 1 samples = 500
+            # Continuing generator: steady-state threshold (kernel fixed at construction, no per-
+            # fill N). Shows the steady 8→7 at m=7; correctly *unchanged* at m=5,6 short N.
+            gen = GNSSSignals.CodeGeneratorLUT(plan, fs, fc)
+            grp["generator"] = @benchmarkable gen_code!($o8, $gen) evals = 1 samples = 500
         end
     end
 end

--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -188,7 +188,7 @@ amplitudes only scale the replica, the **sign pattern is identical to the float
   sub-chip residual is dropped (up to ~1 sub-chip vs the plain `gen_code!`).
   `start_phase = 0.0, start_index_shift = 0` gives `phase = 0` exactly.
 - **High-oversampling run-fill is approximate to ≤ a couple of samples.** Above
-  ~8× sub-chip oversampling the resampler broadcast-fills runs of identical chips
+  ~7× sub-chip oversampling (AVX-512; ~4× on AVX2) the resampler broadcast-fills runs of identical chips
   (matching the original `gen_code!`'s speed there) using a fixed-point samples-
   per-chip DDA. Its chip boundaries are exact for any single fill and drift at
   most a couple of samples only over a *very* long continued stream (~10⁶ chips) —

--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -188,7 +188,7 @@ amplitudes only scale the replica, the **sign pattern is identical to the float
   sub-chip residual is dropped (up to ~1 sub-chip vs the plain `gen_code!`).
   `start_phase = 0.0, start_index_shift = 0` gives `phase = 0` exactly.
 - **High-oversampling run-fill is approximate to ≤ a couple of samples.** Above
-  ~7× sub-chip oversampling (AVX-512; ~4× on AVX2) the resampler broadcast-fills runs of identical chips
+  ~7× sub-chip oversampling for long fills (AVX-512; lower for short fills and ~4× on AVX2) the resampler broadcast-fills runs of identical chips
   (matching the original `gen_code!`'s speed there) using a fixed-point samples-
   per-chip DDA. Its chip boundaries are exact for any single fill and drift at
   most a couple of samples only over a *very* long continued stream (~10⁶ chips) —

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -547,16 +547,18 @@ end
 #   • Steady state (long fills): permute is ~36 ps/sample, flat in oversampling; run-fill is
 #     ~216/m ps/sample (fewer chip-boundary recomputes as runs lengthen), so it overtakes at
 #     m ≈ 6–7 on AVX-512 (7 = smallest m where it wins at every length). The other backends'
-#     slower permute crosses earlier: AVX2 `vpshufb` (~85 ps) ≈ 4, NEON `tbl1` ≈ 3, Portable
-#     (per-sample scalar lookup) ≈ 2.
+#     slower permute crosses earlier: AVX2 `vpshufb` (~85 ps) ≈ 3 (run-fill's 216/3 ≈ 72 ps
+#     beats it; measured N-independent, as ~85 ps sits between 216/3 and 216/2 ≈ 108), NEON
+#     `tbl1` ≈ 3, Portable (per-sample scalar lookup) ≈ 2.
 #   • Short fills: permute pays a fixed ~37 ns init (4× `_init_rel`, a 64-lane `vpmullq`
 #     running-product setup per stream) vs run-fill's ~15 ns (one Int128 freqfix divide), a
-#     ~22 ns edge that ∝ 1/N pulls the crossover to lower m. The AVX-512 sweep puts it at
-#     m ≈ 4 by N ≈ 512 and 5 by N ≈ 1–4k, rising back to 7 once the init amortises — so the
-#     threshold is lowered for short fills. AVX2/NEON/Portable have no small-N sweep yet, so
-#     they stay flat (a conservative over-estimate for short fills there).
+#     ~22 ns edge that ∝ 1/N pulls the crossover to lower m. This only matters when permute is
+#     fast: on AVX-512 the sweep puts it at m ≈ 4 by N ≈ 512 and 5 by N ≈ 1–4k, rising back to
+#     7 once the init amortises — so the AVX-512 threshold is lowered for short fills. AVX2 is
+#     slow enough that its crossover stays at 3 for all N (no small-N adjustment needed); NEON/
+#     Portable have no small-N sweep yet, so they stay flat too.
 @inline _runfill_min_m(::AVX512, N::Int) = N < 1024 ? 4 : N < 4096 ? 5 : 7
-@inline _runfill_min_m(::AVX2, ::Int)     = 4
+@inline _runfill_min_m(::AVX2, ::Int)     = 3
 @inline _runfill_min_m(::Neon, ::Int)     = 3
 @inline _runfill_min_m(::Portable, ::Int) = 2
 @inline _use_runfill(step_num::Int, step_den::Int, backend::Backend, N::Int) =

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -541,25 +541,33 @@ function _generate_runfill!(out, table::CodeTable, step_num::Int, step_den::Int,
     _runfill_seg_dispatch!(out, table.chips, table.length, ff, ni, c, _RUNFILL_MASK, 0)
 end
 
-# Pick the run-fill path when there are at least `_runfill_min_m(backend, N)` samples per
-# chip (N = fill length). The threshold is the per-chip count where broadcast-fill overtakes
-# the windowed permute; two effects set it, both measured on Zen 5:
-#   • Steady state (long fills): permute is ~36 ps/sample, flat in oversampling; run-fill is
-#     ~216/m ps/sample (fewer chip-boundary recomputes as runs lengthen), so it overtakes at
-#     m ≈ 6–7 on AVX-512 (7 = smallest m where it wins at every length). The other backends'
+# Pick the run-fill path when there are at least `_runfill_min_m` samples per chip. The
+# threshold is the per-chip count where broadcast-fill overtakes the windowed permute, set
+# by two effects, both measured on Zen 5:
+#   • Steady state (long fills): permute is ~36 ps/sample on AVX-512, flat in oversampling;
+#     run-fill is ~216/m ps/sample (fewer chip-boundary recomputes as runs lengthen), so it
+#     overtakes at m ≈ 6–7 (7 = smallest m where it wins at every length). The other backends'
 #     slower permute crosses earlier: AVX2 `vpshufb` (~85 ps) ≈ 3 (run-fill's 216/3 ≈ 72 ps
-#     beats it; measured N-independent, as ~85 ps sits between 216/3 and 216/2 ≈ 108), NEON
-#     `tbl1` ≈ 3, Portable (per-sample scalar lookup) ≈ 2.
+#     beats it; N-independent, as ~85 ps sits between 216/3 and 216/2 ≈ 108), NEON `tbl1` ≈ 3,
+#     Portable (per-sample scalar lookup) ≈ 2. This is the `_runfill_min_m(backend)` below.
 #   • Short fills: permute pays a fixed ~37 ns init (4× `_init_rel`, a 64-lane `vpmullq`
 #     running-product setup per stream) vs run-fill's ~15 ns (one Int128 freqfix divide), a
-#     ~22 ns edge that ∝ 1/N pulls the crossover to lower m. This only matters when permute is
+#     ~22 ns edge that ∝ 1/N pulls the crossover to lower m. Only matters where permute is
 #     fast: on AVX-512 the sweep puts it at m ≈ 4 by N ≈ 512 and 5 by N ≈ 1–4k, rising back to
-#     7 once the init amortises — so the AVX-512 threshold is lowered for short fills. AVX2 is
-#     slow enough that its crossover stays at 3 for all N (no small-N adjustment needed); NEON/
-#     Portable have no small-N sweep yet, so they stay flat too.
-@inline _runfill_min_m(::AVX512, N::Int) = N < 1024 ? 4 : N < 4096 ? 5 : 7
-@inline _runfill_min_m(::AVX2, ::Int)     = 3
-@inline _runfill_min_m(::Neon, ::Int)     = 3
-@inline _runfill_min_m(::Portable, ::Int) = 2
-@inline _use_runfill(step_num::Int, step_den::Int, backend::Backend, N::Int) =
+#     the steady 7 once the init amortises. This is the `_runfill_min_m(backend, N)` overload.
+# Only the one-shot `generate_code!` knows the fill length, so only it can use the N-aware
+# overload; the continuing generator (`make_generator`) fixes its kernel at construction
+# before any N is known, so it uses the steady-state threshold — correct for its typical
+# large-epoch fills.
+@inline _runfill_min_m(::AVX512)   = 7
+@inline _runfill_min_m(::AVX2)     = 3
+@inline _runfill_min_m(::Neon)     = 3
+@inline _runfill_min_m(::Portable) = 2
+# N-aware overload (one-shot fills): lower the threshold for short fills. Only AVX-512's
+# permute is fast enough for this to matter; the others fall back to their steady threshold.
+@inline _runfill_min_m(be::AVX512, N::Int) = N < 1024 ? 4 : N < 4096 ? 5 : _runfill_min_m(be)
+@inline _runfill_min_m(be::Backend, ::Int) = _runfill_min_m(be)
+@inline _use_runfill(step_num::Int, step_den::Int, backend::Backend) =          # continuing
+    step_den ÷ step_num >= _runfill_min_m(backend)
+@inline _use_runfill(step_num::Int, step_den::Int, backend::Backend, N::Int) =  # one-shot (N-aware)
     step_den ÷ step_num >= _runfill_min_m(backend, N)

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -87,7 +87,7 @@ function generate_code!(out::AbstractVector{<:Integer}, table::CodeTable,
         throw(ArgumentError("need 0 < step_denominator ≤ 2^$_B"))
     (0 < step_numerator ≤ step_denominator) ||
         throw(ArgumentError("need 0 < step_numerator ≤ step_denominator (must oversample, chips/sample ≤ 1)"))
-    if _use_runfill(Int(step_numerator), Int(step_denominator), backend)
+    if _use_runfill(Int(step_numerator), Int(step_denominator), backend, length(out))
         _generate_runfill!(out, table, Int(step_numerator), Int(step_denominator), Int(phase))
     else
         _generate!(out, table, Int(step_numerator), Int(step_denominator), Int(phase), backend)
@@ -541,22 +541,23 @@ function _generate_runfill!(out, table::CodeTable, step_num::Int, step_den::Int,
     _runfill_seg_dispatch!(out, table.chips, table.length, ff, ni, c, _RUNFILL_MASK, 0)
 end
 
-# Pick the run-fill path when there are at least `_runfill_min_m(backend)` samples per chip.
-# The threshold is the per-chip count where broadcast-fill overtakes the (flat-in-over-
-# sampling) windowed permute, so it depends on how fast that backend's permute is. Tuned from
-# a run-fill-vs-permute crossover sweep (AVX-512 measured locally; AVX2/NEON on the CI
-# benchmark runners, x86 Ubuntu + Apple-Silicon macOS):
-#   • AVX-512 `vpermb` is fast (~38 ps/sample steady-state on Zen 5); a permute-vs-run-fill
-#     sweep puts the crossover at m ≈ 6–7 (run-fill clearly wins from m = 7 at every fill
-#     length; m = 6 is a near-tie, and m = 5 only wins on short ~2k-sample fills where the
-#     permute init isn't yet amortised). Pick 7 — the smallest m where run-fill wins outright.
-#   • AVX2 `vpshufb` (~85 ps) crosses around m ≈ 4.
-#   • NEON `tbl1` is a 16-wide single-window lookup (slowest permute), so run-fill wins from
-#     m = 3 (m = 2 is a tie).
-#   • Portable's "permute" is a per-sample scalar lookup → run-fill wins as soon as runs exist.
-@inline _runfill_min_m(::AVX512)   = 7
-@inline _runfill_min_m(::AVX2)     = 4
-@inline _runfill_min_m(::Neon)     = 3
-@inline _runfill_min_m(::Portable) = 2
-@inline _use_runfill(step_num::Int, step_den::Int, backend::Backend) =
-    step_den ÷ step_num >= _runfill_min_m(backend)
+# Pick the run-fill path when there are at least `_runfill_min_m(backend, N)` samples per
+# chip (N = fill length). The threshold is the per-chip count where broadcast-fill overtakes
+# the windowed permute; two effects set it, both measured on Zen 5:
+#   • Steady state (long fills): permute is ~36 ps/sample, flat in oversampling; run-fill is
+#     ~216/m ps/sample (fewer chip-boundary recomputes as runs lengthen), so it overtakes at
+#     m ≈ 6–7 on AVX-512 (7 = smallest m where it wins at every length). The other backends'
+#     slower permute crosses earlier: AVX2 `vpshufb` (~85 ps) ≈ 4, NEON `tbl1` ≈ 3, Portable
+#     (per-sample scalar lookup) ≈ 2.
+#   • Short fills: permute pays a fixed ~37 ns init (4× `_init_rel`, a 64-lane `vpmullq`
+#     running-product setup per stream) vs run-fill's ~15 ns (one Int128 freqfix divide), a
+#     ~22 ns edge that ∝ 1/N pulls the crossover to lower m. The AVX-512 sweep puts it at
+#     m ≈ 4 by N ≈ 512 and 5 by N ≈ 1–4k, rising back to 7 once the init amortises — so the
+#     threshold is lowered for short fills. AVX2/NEON/Portable have no small-N sweep yet, so
+#     they stay flat (a conservative over-estimate for short fills there).
+@inline _runfill_min_m(::AVX512, N::Int) = N < 1024 ? 4 : N < 4096 ? 5 : 7
+@inline _runfill_min_m(::AVX2, ::Int)     = 4
+@inline _runfill_min_m(::Neon, ::Int)     = 3
+@inline _runfill_min_m(::Portable, ::Int) = 2
+@inline _use_runfill(step_num::Int, step_den::Int, backend::Backend, N::Int) =
+    step_den ÷ step_num >= _runfill_min_m(backend, N)

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -546,12 +546,15 @@ end
 # sampling) windowed permute, so it depends on how fast that backend's permute is. Tuned from
 # a run-fill-vs-permute crossover sweep (AVX-512 measured locally; AVX2/NEON on the CI
 # benchmark runners, x86 Ubuntu + Apple-Silicon macOS):
-#   • AVX-512 `vpermb` is fast (~37 ps/sample), so run-fill only wins from m ≈ 7–8.
+#   • AVX-512 `vpermb` is fast (~38 ps/sample steady-state on Zen 5); a permute-vs-run-fill
+#     sweep puts the crossover at m ≈ 6–7 (run-fill clearly wins from m = 7 at every fill
+#     length; m = 6 is a near-tie, and m = 5 only wins on short ~2k-sample fills where the
+#     permute init isn't yet amortised). Pick 7 — the smallest m where run-fill wins outright.
 #   • AVX2 `vpshufb` (~85 ps) crosses around m ≈ 4.
 #   • NEON `tbl1` is a 16-wide single-window lookup (slowest permute), so run-fill wins from
 #     m = 3 (m = 2 is a tie).
 #   • Portable's "permute" is a per-sample scalar lookup → run-fill wins as soon as runs exist.
-@inline _runfill_min_m(::AVX512)   = 8
+@inline _runfill_min_m(::AVX512)   = 7
 @inline _runfill_min_m(::AVX2)     = 4
 @inline _runfill_min_m(::Neon)     = 3
 @inline _runfill_min_m(::Portable) = 2


### PR DESCRIPTION
Tunes the LUT resampler's run-fill vs windowed-permute selection from measured permute-vs-run-fill crossover sweeps. Targets #69's branch (`feat/code-lut-resampler`). Net diff is 3 files; the commit trail records the validation (and one CI-caught bug + fix) and can be squash-merged.

## Why
The crossover is set by two effects (`total = slope·N + init` fit, Zen 5):

| kernel | slope | fixed init |
|--------|-------|-----------|
| permute (AVX-512) | ~36 ps/sample, flat in oversampling | ~37 ns (4× `_init_rel`, a 64-lane `vpmullq` setup per stream) |
| permute (AVX2) | ~85 ps/sample | similar |
| permute (NEON) | ~208 ps/sample | — |
| run-fill (backend-independent kernel) | ~216/m ps/sample (Zen 5) | ~15 ns (one Int128 freqfix divide) |

So run-fill overtakes permute at **m ≈ 6–7 (AVX-512)**, **3 (AVX2)**, **3 (NEON)**. The old thresholds (AVX-512 = 8, AVX2 = 4) over-shot. On short fills, run-fill's ~22 ns init edge (∝1/N) lowers the AVX-512 crossover further (m≈4 by N=512, 5 by N=1–4k).

## Changes (3 files)
- **AVX-512:** flat `8` → two-tier — steady `_runfill_min_m(::AVX512)=7` for the continuing generator (which fixes its kernel at construction, no per-fill N), plus an N-aware `_runfill_min_m(::AVX512, N)` = `N<1024 ? 4 : N<4096 ? 5 : 7` for the one-shot `generate_code!` (which knows `length(out)`).
- **AVX2:** `4 → 3`.
- **NEON / Portable:** unchanged.
- Docstring + threshold rationale comment refreshed (incl. the stale "~8×").

## Validation (this PR's benchmark CI, since removed)
A temporary dense crossover sweep + a NEON kernel probe were added, run, and removed:
- **AVX2 4→3 — CI-confirmed** on the ubuntu (AVX2) runner: m=3 **1.1–1.36× faster** across all N, both one-shot and generator; m=5,6,7 unchanged (both revs already run-fill there → no regression).
- **NEON keep 3 — CI-confirmed** on macos-14: measured crossover is exactly m=3 (m=2 permute, m=3 run-fill −22%, m=5 −53%).
- **AVX-512 — not CI-validatable** (no AVX-512 runner in the matrix); rests on local Zen 5 measurements.

## Safety
Run-fill and permute are **byte-identical** (verified across the flipped (N,m) cells, one-shot and continuing). Speed-only change. One CI-caught bug (the continuing generator still called the now-4-arg `_use_runfill`) is fixed by the two-tier dispatch above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)