### PR TITLE
refactor: de-duplicate _select_codes_for across negated-cache signals

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -287,6 +287,32 @@ straightforward lookup and does not use this dispatch.
 """
 @inline _select_codes_for(signal::AbstractGNSSSignal, sec_val) = (signal.codes, sec_val)
 
+# Signals whose secondary/overlay chips are ±1 cache an element-wise-negated
+# copy of their primary-code matrix in a `negated_codes` field at construction.
+# For the primary periods where the secondary chip is -1, the worker then reads
+# that pre-negated matrix instead of multiplying every chip by `sec_val`.
+# Selecting the matrix once per primary period (in the worker's outer `k` loop)
+# hoists the multiply out of the hot inner loop and restores the fused
+# load-broadcast pattern, at the cost of storing a second copy of the codes.
+# Each signal's own `negated_codes` field comment records its exact storage cost
+# and speedup.
+#
+# This Union is formed in `common.jl` (included last, after every signal file),
+# so all member types exist. Any new signal that stores a `negated_codes` cache
+# should be added here — that is the single place to touch.
+const NegatedPrimaryCacheSignal = Union{
+    GPSL5I,
+    GPSL5Q,
+    GPSL1C_P,
+    GalileoE5aI,
+    GalileoE5aQ,
+    GalileoE1C,
+    GalileoE1C_BOC11,
+}
+
+@inline _select_codes_for(signal::NegatedPrimaryCacheSignal, sec_val) =
+    sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
+
 # Shared tail loop for both `sample_code_worker!` and
 # `sample_code_worker_generic!`. The tail handles the chips held back
 # from the main loop (`tail_slack`) plus a 3-chip safety margin; each

--- a/src/galileo/e1c.jl
+++ b/src/galileo/e1c.jl
@@ -136,13 +136,9 @@ SharedSecondaryCode{25, Int8}((-1, -1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1, 1, -
 """
 @inline get_secondary_code(::GalileoE1C) = galileo_e1c_secondary_code()
 
-# Specialization of the `_select_codes_for` hot-path helper. Because the
-# CS25 secondary entries are ±1, we pre-negate the primary code matrix at
-# construction (stored as `negated_codes`) and pick the right matrix once
-# per primary period in the worker, avoiding the per-chip multiply.
-@inline function _select_codes_for(signal::GalileoE1C, sec_val)
-    return sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
-end
+# GalileoE1C pre-negates its primary code matrix (CS25 secondary chips are ±1);
+# the shared `_select_codes_for` fast path for such signals lives on
+# `NegatedPrimaryCacheSignal` in `common.jl`.
 
 """
 $(SIGNATURES)
@@ -232,6 +228,5 @@ end
 @inline get_code_frequency(::GalileoE1C_BOC11) = 1023_000Hz
 @inline get_data_frequency(::GalileoE1C_BOC11) = 0Hz
 
-@inline function _select_codes_for(signal::GalileoE1C_BOC11, sec_val)
-    return sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
-end
+# GalileoE1C_BOC11 shares the `NegatedPrimaryCacheSignal` fast path (see
+# `common.jl`).

--- a/src/galileo/e5a.jl
+++ b/src/galileo/e5a.jl
@@ -336,13 +336,6 @@ SIS ICD §3.5), giving a 100 ms tiered code.
 """
 @inline get_secondary_code(s::GalileoE5aQ) = PerPRNSecondaryCode(s.secondary_codes)
 
-# The E5a-I CS20 and E5a-Q CS100 secondary chips are ±1, so for every primary
-# period we select the positive or negated primary-code matrix once (in the
-# worker's outer `k` loop), hoisting the per-chip multiply out of the hot
-# inner loop — the same optimization used by GPSL5I and GPSL1C_P.
-@inline function _select_codes_for(signal::GalileoE5aI, sec_val)
-    return sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
-end
-@inline function _select_codes_for(signal::GalileoE5aQ, sec_val)
-    return sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
-end
+# GalileoE5aI and GalileoE5aQ pre-negate their primary code matrix (CS20/CS100
+# secondary chips are ±1); the shared `_select_codes_for` fast path for such
+# signals lives on `NegatedPrimaryCacheSignal` in `common.jl`.

--- a/src/gps/l1c_p.jl
+++ b/src/gps/l1c_p.jl
@@ -83,13 +83,9 @@ one chip of a 1800-bit per-PRN LFSR-generated overlay code, giving an
 """
 @inline get_secondary_code(s::GPSL1C_P) = PerPRNSecondaryCode(s.overlay_codes)
 
-# Specialization of the `_select_codes_for` hot-path helper. The L1C-P
-# overlay chips are ±1, so for every primary code period we pick the
-# positive or negated code matrix once (in the worker's outer `k`
-# loop), hoisting the per-chip multiply out of the hot inner loop.
-@inline function _select_codes_for(signal::GPSL1C_P, sec_val)
-    return sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
-end
+# GPSL1C_P pre-negates its primary code matrix (overlay chips are ±1); the
+# shared `_select_codes_for` fast path for such signals lives on
+# `NegatedPrimaryCacheSignal` in `common.jl`.
 
 """
 $(SIGNATURES)

--- a/src/gps/l5.jl
+++ b/src/gps/l5.jl
@@ -389,14 +389,6 @@ SharedSecondaryCode{20, Int8}((1, 1, 1, 1, 1, -1, 1, 1, -1, -1, 1, -1, 1, -1, 1,
     )
 end
 
-# Specialization of the `_select_codes_for` hot-path helper. Because the NH10
-# and NH20 secondary entries are ±1, we pre-negate the primary code matrix at
-# construction (stored as `negated_codes`) and pick the right matrix once per
-# primary period in the worker, avoiding the per-chip multiply that would
-# otherwise prevent the fused load-broadcast pattern.
-@inline function _select_codes_for(signal::GPSL5I, sec_val)
-    return sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
-end
-@inline function _select_codes_for(signal::GPSL5Q, sec_val)
-    return sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
-end
+# GPSL5I and GPSL5Q pre-negate their primary code matrix (NH10/NH20 secondary
+# chips are ±1); the shared `_select_codes_for` fast path for such signals lives
+# on `NegatedPrimaryCacheSignal` in `common.jl`.


### PR DESCRIPTION
## Summary

The pre-negated primary-code cache fast path in `_select_codes_for` was
copy-pasted byte-for-byte across seven signal types:

- `GPSL5I`, `GPSL5Q` (`src/gps/l5.jl`)
- `GPSL1C_P` (`src/gps/l1c_p.jl`)
- `GalileoE5aI`, `GalileoE5aQ` (`src/galileo/e5a.jl`)
- `GalileoE1C`, `GalileoE1C_BOC11` (`src/galileo/e1c.jl`)

Each defined the identical method:

```julia
@inline function _select_codes_for(signal::GPSL5I, sec_val)
    return sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
end
```

The real cost is a footgun for the next signal: anyone adding a new
tiered-code signal had to remember to paste this method, or it would
silently fall back to the slower generic path (`(signal.codes, sec_val)`
with the per-chip multiply), quietly losing the fused load-broadcast
optimization the cache exists to enable.

## Change

Define the fast path **once** in `src/common.jl` on a `NegatedPrimaryCacheSignal`
`Union` of the seven cache-bearing types, and delete the seven per-signal
overrides (each replaced with a short pointer comment).

```julia
const NegatedPrimaryCacheSignal = Union{
    GPSL5I, GPSL5Q, GPSL1C_P,
    GalileoE5aI, GalileoE5aQ, GalileoE1C, GalileoE1C_BOC11,
}

@inline _select_codes_for(signal::NegatedPrimaryCacheSignal, sec_val) =
    sec_val > 0 ? (signal.codes, true) : (signal.negated_codes, true)
```

The inclusion rule is precise: a signal belongs in the `Union` iff its struct
has a `negated_codes` field, which exists only for signals with a ±1
tiered/overlay secondary code. Adding a new tiered-code signal is now a
one-line edit to the `Union` — the single place to touch.

## Why it's zero-cost

- `Union{concrete types...}` is strictly more specific than the
  `AbstractGNSSSignal` default, so dispatch resolves to this method for those
  signals — and it resolves **at compile time** for a concrete signal type, so
  the hot path is byte-for-byte the same machine code as before. No runtime
  branch, no trait indirection.
- `common.jl` is `include`d **last** (after every signal file), so all seven
  types exist when the `Union` is formed.
- Signals with `NoSecondaryCode()` and thus no `negated_codes` cache
  (`GPSL1CA`, `GPSL1C_D`, `GPSL2CM`, `GPSL2CL`, `GalileoE1B`,
  `GalileoE1B_BOC11`) are unaffected — they keep hitting the generic default.

## Verification

- `using GNSSSignals` loads clean.
- Dispatch confirmed: all seven cache-bearing types resolve to the `Union`
  method; signals without a cache (e.g. `GPSL2CM`) correctly fall through to
  the generic default.
- Full `Pkg.test()` suite passes.

Internal refactor — non-breaking, no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)