### PR TITLE
fix(code_lut): apply non-baked secondary on the DDA-correct sample

### DIFF
--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -372,6 +372,7 @@ struct CodeFillEngine{E<:CodeLUT.FillEngineAny}
     step_num::Int             # sub-chip step over the *sub-chip* table
     step_den::Int
     phase_sub::Int            # initial sub-chip phase offset
+    rem0::Int                 # initial fractional sub-chip residual (for the secondary boundaries)
 end
 
 """
@@ -435,7 +436,7 @@ function code_engine(
     engine = CodeLUT.make_fill_engine(mc.table, sn, sd; phase = phase_sub, rem0 = rem0, backend = backend)
     # `mc.secondary` is a view into `signal.lut.secondary`; materialise it as an owning Vector
     # so the engine does not alias the (otherwise read-only) embedded matrix.
-    return _wrap_code_fill_engine(engine, collect(mc.secondary), mc.period_subchips, P, sn, sd, phase_sub)
+    return _wrap_code_fill_engine(engine, collect(mc.secondary), mc.period_subchips, P, sn, sd, phase_sub, Int(rem0))
 end
 
 # Function barrier. `make_fill_engine` returns a small Union over the phase type (Int16 vs
@@ -445,10 +446,10 @@ end
 # every construction (the one-shot/threaded allocation hot spot).
 function _wrap_code_fill_engine(
     engine::E, secondary, period_subchips,
-    subchip_factor, step_num, step_den, phase_sub,
+    subchip_factor, step_num, step_den, phase_sub, rem0,
 ) where {E<:CodeLUT.FillEngineAny}
     CodeFillEngine{E}(
-        engine, secondary, period_subchips, subchip_factor, step_num, step_den, phase_sub,
+        engine, secondary, period_subchips, subchip_factor, step_num, step_den, phase_sub, rem0,
     )
 end
 
@@ -478,18 +479,20 @@ end
     length(sec) <= 1 && return out
     Ls = length(sec); per = eng.period_subchips
     sn = eng.step_num; sd = eng.step_den
-    N = length(out); ps = eng.phase_sub
-    # Absolute sample n (0-based) maps to sub-chip floor(n·sn/sd) + ps; period p spans
-    # sub-chips [p·per, (p+1)·per). First sample of period p: smallest n with sub-chip ≥ p·per.
+    N = length(out); ps = eng.phase_sub; r0 = eng.rem0
+    # Absolute sample n (0-based) maps to sub-chip floor((n·sn + rem0)/sd) + ps; period p spans
+    # sub-chips [p·per, (p+1)·per). First sample of period p: smallest n with sub-chip ≥ p·per,
+    # i.e. n ≥ cld(T·sd − rem0, sn) (T·sd > rem0 whenever T ≥ 1, since rem0 < sd). Omitting rem0
+    # would misplace the sign flip by a sample at a period edge for a fractional start phase.
     # The first emitted sample is absolute n0, so window index = n - n0.
-    sub0 = (n0 * sn) ÷ sd + ps
-    p = (sub0) ÷ per                # period index of the first emitted sample
+    sub0 = (n0 * sn + r0) ÷ sd + ps
+    p = fld(sub0, per)              # period index of the first emitted sample
     @inbounds while true
         T0 = p * per - ps
-        n_start = T0 <= 0 ? 0 : cld(T0 * sd, sn)      # absolute first sample of period p
+        n_start = T0 <= 0 ? 0 : cld(T0 * sd - r0, sn) # absolute first sample of period p
         n_start - n0 >= N && break
         T1 = (p + 1) * per - ps
-        n_end = min(T1 <= 0 ? 0 : cld(T1 * sd, sn), n0 + N)  # absolute end (exclusive)
+        n_end = min(T1 <= 0 ? 0 : cld(T1 * sd - r0, sn), n0 + N)  # absolute end (exclusive)
         if sec[mod(p, Ls) + 1] == -1
             lo = max(n_start, n0) - n0 + 1            # 1-based into out
             hi = n_end - n0                            # 1-based inclusive

--- a/src/code_lut/modulation.jl
+++ b/src/code_lut/modulation.jl
@@ -150,27 +150,35 @@ function generate_code!(out::AbstractVector{<:Integer}, mc::ModulatedCode;
     generate_code!(out, mc.table;
         code_frequency = code_frequency * mc.subchip_factor, sampling_frequency = sampling_frequency,
         phase = phase_sub, rem0 = rem0, backend = backend)
-    any(!=(Int8(1)), mc.secondary) && _apply_secondary!(out, mc, code_frequency, sampling_frequency, Int(phase_sub))
+    any(!=(Int8(1)), mc.secondary) &&
+        _apply_secondary!(out, mc, code_frequency, sampling_frequency, Int(phase_sub), _RemT(rem0))
     out
 end
 
 # Multiply each whole primary period by its secondary chip. The secondary is constant over
 # a period (period_subchips sub-chips), so we negate contiguous sample ranges — a handful
 # of vectorisable negates, not a per-sample multiply. `phase_sub` is the integer sub-chip
-# start offset (θ_int).
-function _apply_secondary!(out, mc::ModulatedCode, code_frequency, sampling_frequency, phase_sub)
+# start offset (θ_int); `rem0` the fractional sub-chip residual seeded into the DDA (both must
+# match the baked-table lookup, or the sign flip lands on the wrong sample at a period edge).
+function _apply_secondary!(out, mc::ModulatedCode, code_frequency, sampling_frequency, phase_sub,
+                           rem0::_RemT = _RemT(0))
     Ls = length(mc.secondary); per = mc.period_subchips
     sn, sd = _fixed_point_step(code_frequency * mc.subchip_factor / sampling_frequency)
-    phase_sub = Int(phase_sub)
-    N = length(out); p = 0
-    # sample n maps to sub-chip floor(n·sn/sd) + phase_sub; period p spans sub-chips
-    # [p·per, (p+1)·per). First sample of period p: smallest n with that sub-chip ≥ p·per.
+    phase_sub = Int(phase_sub); r0 = Int(rem0)
+    N = length(out)
+    # sample n (0-based) maps to sub-chip floor((n·sn + rem0)/sd) + phase_sub; period p spans
+    # sub-chips [p·per, (p+1)·per). First sample of period p: smallest n with that sub-chip
+    # ≥ p·per, i.e. n ≥ cld(T·sd − rem0, sn) (T·sd > rem0 whenever T ≥ 1, since rem0 < sd).
+    # Start at the period sample 0 falls in (A(0) = phase_sub) — NOT 0: a negative
+    # start_index_shift puts sample 0 in a negative period, and start_phase ≥ one code period
+    # in a period ≥ 1; starting at 0 would apply the wrong secondary chip to the leading samples.
+    p = fld(phase_sub, per)
     @inbounds while true
         T = p * per - phase_sub
-        s_p = T <= 0 ? 0 : cld(T * sd, sn)
+        s_p = T <= 0 ? 0 : cld(T * sd - r0, sn)
         s_p >= N && break
         Tn = (p + 1) * per - phase_sub
-        s_next = min(Tn <= 0 ? 0 : cld(Tn * sd, sn), N)
+        s_next = min(Tn <= 0 ? 0 : cld(Tn * sd - r0, sn), N)
         if mc.secondary[mod(p, Ls) + 1] == -1
             @simd for n in (s_p + 1):s_next
                 out[n] = -out[n]

--- a/test/common.jl
+++ b/test/common.jl
@@ -85,37 +85,25 @@ end
 const _CL = GNSSSignals.CodeLUT
 
 # Shared fixed-point scalar oracle (defined here so test/code_lut.jl and test/signal_lut.jl,
-# both included after common.jl, can reuse it). Builds the secondary-FREE resample from the
-# baked column `full` exactly as the kernel does — sample n (1-based) reads sub-chip
-# `((sn·(n-1) + rem0) >> _B) + psub` (mod L) — then applies any non-baked `sec` as a
-# per-primary-period range-negate, mirroring `GNSSSignals._apply_secondary!` precisely
-# (period boundaries via `cld((p·per − psub)·sd, sn)`, on the integer `psub` only). Byte-exact
-# vs the embedded gen_code! in the permute regime; the run-fill regime gets a ≤2-sample
-# boundary tolerance at the call site. `sec` is the per-PRN residual vector (`Int8[1]` = none).
+# both included after common.jl, can reuse it). This is the INDEPENDENT definition of correct
+# output: for each sample n (1-based) it forms the absolute sub-chip phase
+# `A = ((sn·(n-1) + rem0) >> _B) + psub`, reads the baked chip `full[mod(A, Lf) + 1]`, and — for
+# a non-baked `sec` — multiplies by the secondary chip of that sample's OWN primary period
+# `fld(A, per)`. Deriving the period from the very same `A` as the chip lookup (rather than
+# re-deriving period boundaries the way `_apply_secondary!` does) is deliberate: it makes the
+# oracle a genuine check on the boundary math instead of a mirror of it. Byte-exact vs the
+# embedded gen_code! in the permute regime; the run-fill regime gets a ≤2-sample boundary
+# tolerance at the call site. `sec` is the per-PRN residual vector (`Int8[1]` = none).
 function _gen_code_scalar_oracle(full, sn::Int, sd::Int, rem0::Int, psub::Int, N::Int,
                                  sec::AbstractVector{Int8}, per::Int)
-    Lf = length(full)
+    Lf = length(full); Ls = length(sec)
+    has_sec = any(!=(Int8(1)), sec)
     ref = Vector{Int8}(undef, N)
     @inbounds for i in 1:N
-        subi = ((sn * Int64(i - 1) + Int64(rem0)) >> _CL._B) + psub
-        ref[i] = full[mod(subi, Lf) + 1]
-    end
-    Ls = length(sec)
-    if any(!=(Int8(1)), sec)
-        p = 0
-        @inbounds while true
-            T = p * per - psub
-            s_p = T <= 0 ? 0 : cld(T * sd, sn)
-            s_p >= N && break
-            Tn = (p + 1) * per - psub
-            s_next = min(Tn <= 0 ? 0 : cld(Tn * sd, sn), N)
-            if sec[mod(p, Ls) + 1] == -1
-                for n in (s_p + 1):s_next
-                    ref[n] = -ref[n]
-                end
-            end
-            p += 1
-        end
+        A = ((sn * Int64(i - 1) + Int64(rem0)) >> _CL._B) + psub
+        chip = full[mod(A, Lf) + 1]
+        has_sec && (chip *= sec[mod(fld(A, per), Ls) + 1])
+        ref[i] = chip
     end
     ref
 end
@@ -196,6 +184,43 @@ end
     sampling_rate = 25e6Hz
     for samples in (1, 2, 3, 5, 7, 63, 65, 127, 129)
         @test_nowarn _check_gen_code(signal, 1, sampling_rate, get_code_frequency(signal), 3.5, 0, samples)
+    end
+end
+
+# Regression: a fractional start phase (nonzero sub-chip residual `rem0`) together with a
+# NON-baked secondary (GPS L5I's NH10, GPS L1C-P's overlay) must still flip the secondary sign
+# on exactly the sample the DDA places at each primary-period boundary. The earlier code
+# derived the boundary from `psub` alone (ignoring `rem0`), misplacing the flip by one sample
+# at each transition. This needs enough samples to cross several secondary periods AND a
+# fractional phase — the short/integer-phase cases above never exercised it. Byte-exact in the
+# permute regime, so `_check_gen_code` asserts equality against the independent oracle.
+@testset "Fractional phase + non-baked secondary $(get_signal_name(signal))" for signal in [
+    GPSL5I(),
+    GPSL1C_P(),
+]
+    fc = get_code_frequency(signal)
+    P = signal.lut.subchip_factor
+    per = signal.lut.period_subchips
+    sampling_rate = fc * P * 5 // 2                       # permute regime, sub-chip oversampled
+    sec = GNSSSignals._signal_lut_secondary(signal.lut, 1); Ls = length(sec)
+    # Size the buffer to cross the first secondary sign transition (a couple of periods past it),
+    # so the test is non-vacuous for both the 10-chip NH10 (L5I) and the 1800-chip overlay
+    # (L1C-P, whose primary period — hence per-period sample count — is ~12× longer).
+    s0 = sec[1]
+    flip = findfirst(p -> sec[mod(p, Ls) + 1] != s0, 1:Ls)
+    @test flip !== nothing                                # residual secondary must actually vary
+    samples_per_period = per * 5 ÷ 2                      # per / cps, cps = 2/5
+    num_samples = (flip + 2) * samples_per_period
+    for (sp, sis) in ((0.3, 0), (0.7, 0), (1.7, 0), (0.0, -1), (2.4, 3))
+        one = _check_gen_code(signal, 1, sampling_rate, fc, sp, sis, num_samples)
+        # continuing engine (chunked) must reproduce the one-shot across period + call boundaries
+        eng = code_engine(signal, 1, sampling_rate, fc; start_phase = sp, start_index_shift = sis)
+        st = code_state(eng); got = Int8[]
+        h = num_samples ÷ 2
+        for ch in (1, h, 64, num_samples - 1 - h - 64)
+            b = Vector{Int8}(undef, ch); st = gen_code!(b, eng, st); append!(got, b)
+        end
+        @test got == one
     end
 end
 


### PR DESCRIPTION
Stacks on top of #69. Fixes two correctness bugs in how the **non-baked secondary** (GPS L5I NH10, GPS L1C-P overlay) is applied when resampling from the embedded `SignalLUT`. Both were silent because the test oracle re-implemented the same boundary math it was meant to check.

## Bug 1 — fractional start phase misplaces the sign flip
The baked-table lookup advances the DDA as `floor((n·sn + rem0) / 2^_B)` (includes the fractional sub-chip residual `rem0`), but the secondary period boundaries were computed as `cld(T·sd, sn)` — **omitting `rem0`**. For any non-integer `start_phase`, the NH10/overlay sign flip lands on the wrong sample at each primary-period transition.

Empirically on GPS L5I (fs=25 MHz, 250k samples), comparing `gen_code!` against ground truth where the period is derived from the same DDA phase as the chip lookup:

| start_phase | mismatches (before) | mismatches (after) |
|---|---|---|
| 0.0 | 0 | 0 |
| 0.3 | 5 | 0 |
| 0.7 | 11 | 0 |
| 1.7 | 12 | 0 |

Fix: thread `rem0` through `_apply_secondary!` (one-shot) and `_apply_secondary_continue!` (continuing engine, via a new `rem0` field on `CodeFillEngine`), using `cld(T·sd − rem0, sn)`.

## Bug 2 — leading period index (exposed by the independent oracle)
`_apply_secondary!` started its period loop at `p = 0` instead of the period sample 0 actually falls in. A negative `start_index_shift` (sample 0 in period −1) or a `start_phase ≥ one code period` (period ≥ 1) applied the wrong secondary chip to the leading samples. Fixed by starting at `p = fld(phase_sub, per)`, matching the continuing path.

## Test oracle made independent (#3)
`_gen_code_scalar_oracle` mirrored `_apply_secondary!`'s boundary formula, so it could never catch a bug in it. It now derives each sample's period from the **same** DDA phase `A` used for the chip lookup (`fld(A, per)`). Added a `Fractional phase + non-baked secondary` regression testset (GPS L5I + GPS L1C-P) crossing several secondary periods with fractional / negative / large-than-a-period start phases, asserting both the one-shot and chunked-continuation output. It **fails on the pre-fix code and passes after**.

Full suite green (Julia 1.12, AVX-512 VBMI host); both new testsets 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)