### PR TITLE
feat(code_lut): unify run-fill into an exact boundary-fill kernel

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -84,10 +84,12 @@ end
 # plain BPSK): its oversampling ratio equals the table-oversampling, so 2× exercises the permute
 # path and 8×–32× the boundary fill around the switch. 17×/24× are non-power-of-two ratios (mixed
 # m/m+1 runs, the magic-reciprocal path); 8×/32× are power-of-two (the shift path) on the SW = 16
-# and SW = 64 store widths.
+# and SW = 64 store widths. 64×/128× cover runs longer than the widest store (the EXTRAS strided
+# interior stores) — the region where the old run-fill fell off its `Val` ladder into the slow
+# generic kernel.
 # ─────────────────────────────────────────────────────────────────────────────
 let signal = _GPSL1(), fc = 1023e3Hz
-    for oversampling in (2, 8, 17, 24, 32), (slabel, n) in (("4k", 4096), ("64k", 65536))
+    for oversampling in (2, 8, 17, 24, 32, 64, 128), (slabel, n) in (("4k", 4096), ("64k", 65536))
         fs = oversampling * fc
         out = _buf(signal, n)
         # evals = 10 (average out per-call scheduling jitter — the 4k fills run in a few

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -79,12 +79,12 @@ end
 # ─────────────────────────────────────────────────────────────────────────────
 # oversampling sweep — gen_code! across oversampling ratios (fs/fc = samples per chip) at a small
 # (4k) and steady-state (64k) buffer. Guards the LUT's ratio-dependent path selection: the windowed
-# permute (flat in the ratio) at low oversampling, switching to a broadcast run-fill once the baked
-# table is oversampled ≳7× (AVX-512) / ≳4× (AVX2). One representative signal (GPS L1 C/A, plain
-# BPSK): its oversampling ratio equals the table-oversampling, so 2× exercises the permute path and
-# 8×/32× the run-fill across the threshold. 17×/24× are non-power-of-two run-fill ratios: their
-# per-chip run length (17/24) is padded to a non-power-of-two store width by `_runfill_pad`, so
-# these rows track the run-fill broadcast-store width tuning (the power-of-two ratios never do).
+# permute (flat in the ratio) at low oversampling, switching to the exact boundary fill once the
+# baked table is oversampled ≳10× (AVX-512) / ≳4× (AVX2). One representative signal (GPS L1 C/A,
+# plain BPSK): its oversampling ratio equals the table-oversampling, so 2× exercises the permute
+# path and 8×–32× the boundary fill around the switch. 17×/24× are non-power-of-two ratios (mixed
+# m/m+1 runs, the magic-reciprocal path); 8×/32× are power-of-two (the shift path) on the SW = 16
+# and SW = 64 store widths.
 # ─────────────────────────────────────────────────────────────────────────────
 let signal = _GPSL1(), fc = 1023e3Hz
     for oversampling in (2, 8, 17, 24, 32), (slabel, n) in (("4k", 4096), ("64k", 65536))

--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -14,9 +14,9 @@
 # The LUT resampler bakes the BOC/TMBOC subcarrier (and short secondary codes)
 # into an expanded ±1 Int8 table and resamples it with a single AVX-512 `vpermb`
 # / AVX2 `vpshufb` sliding-window permute over a drift-free integer DDA — or, once the
-# baked table is heavily oversampled (so consecutive samples repeat a chip), a broadcast
-# run-fill that matches the original `gen_code!`'s store-bound speed instead of paying a
-# permute per window. The baked table is Int8: ±1 for BPSK/BOC/TMBOC, or a multi-level
+# baked table is heavily oversampled (so consecutive samples repeat a chip), an exact
+# boundary fill that splat-stores one chip run per store at the original `gen_code!`'s
+# store-bound speed instead of paying a permute per window. The baked table is Int8: ±1 for BPSK/BOC/TMBOC, or a multi-level
 # integer approximation of the sqrt-power amplitudes for CBOC (Galileo E1B); cosine-BOC is
 # unsupported. Requires sub-chip oversampling (`sampling_frequency ≥ code_frequency · subchip_factor`).
 # ─────────────────────────────────────────────────────────────────────────────
@@ -268,7 +268,7 @@ end
 Generate the sampled spreading code for PRN `prn` of `signal` in-place, by resampling PRN
 `prn`'s fully-modulated baked replica from the signal's embedded `SignalLUT`. This is THE code
 generator: it wraps PRN `prn`'s baked column in a zero-copy view-backed table and drives the
-SIMD windowed-permute / run-fill resampler.
+SIMD windowed-permute / boundary-fill resampler.
 
 # Output
 `sampled_code` must be `Vector{Int8}` (or any `AbstractVector{Int8}`). Non-CBOC signals are
@@ -388,7 +388,7 @@ sign flips across call boundaries). Seed it with [`code_state`](@ref)`(eng)` and
 value returned by [`gen_code!`](@ref)`(out, eng, st)` into the next call.
 """
 struct CodeFillState{St}
-    dda::St          # backend DDA state (CodeState512 / CodeStatePhase / RunFillState)
+    dda::St          # backend DDA state (CodeState512 / CodeStatePhase / BoundaryState)
     n_abs::Int       # absolute sample offset of the next sample to emit
 end
 

--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -272,7 +272,9 @@ function FillEngineBoundary(table::CodeTable, step_num::Int, step_den::Int, phas
     c0 = Int(mod(Int64(rem0) >> _B + phase_offset, table.length))
     r0 = _RemT(Int64(rem0) & Int64(step_den - 1))
     m = _STEP_DEN ÷ step_num
-    if m <= 14
+    if m <= 6
+        FillEngineBoundary{8,false}(table.padded, table.length, step_num, c0, r0)
+    elseif m <= 14
         FillEngineBoundary{16,false}(table.padded, table.length, step_num, c0, r0)
     elseif m <= 30
         FillEngineBoundary{32,false}(table.padded, table.length, step_num, c0, r0)

--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -9,8 +9,8 @@
 #
 # State is explicit and immutable: a single canonical "stream 0" `(rel, rem, base)` at the
 # current absolute sample offset (AVX-512 rel/scalar-base form, reusing `CodeState512`), or
-# the phase-based equivalent (`CodeStatePhase`) for AVX2/Portable, or `(c, acc, pos)`
-# (`RunFillState`) for the high-oversampling run-fill path. `fill_continue!(out, eng, st)`
+# the phase-based equivalent (`CodeStatePhase`) for AVX2/Portable, or `(c, r)`
+# (`BoundaryState`) for the high-oversampling boundary-fill path. `fill_continue!(out, eng, st)`
 # returns the state advanced by exactly `length(out)`, so the caller threads it — no mutation,
 # no hidden state, and an isbits state means the steady-state fill is allocation-free.
 #
@@ -244,56 +244,59 @@ end
     (ph, r)
 end
 
-# ---- continuing run-fill engine (high-oversampling fast path) ----
-# The continuing counterpart of `_generate_runfill!`: at high oversampling broadcast-fills
-# runs of identical baked chips (store-bandwidth bound) instead of one permute per W samples.
-# Effectively byte-identical to the permute engines (the approximate samples-per-chip DDA in
-# `_runfill_core!` matches the exact `floor(step_num·n/2^_B)` boundaries for any single fill,
-# drifting ≤ a couple of samples only over ~10⁵ continued chips). State carried across fills
-# is `RunFillState(c, acc, pos)`: the table chip index, the chip-start fractional phase `acc`,
-# and `pos` = samples of the current chip already emitted (so a fill may resume mid-run).
-#
-# `NI` (the padded fixed inner-store count) is a *type* parameter so `fill_continue!` calls
-# the `Val{NI}`-specialised kernel statically — a runtime `Val(ni)` would box and allocate
-# every call, breaking the 0-alloc steady-state guarantee. `NI == 0` is the sentinel for the
-# generic (`ni > _RUNFILL_MAX_NI`) kernel, whose runtime count lives in the `ni` field.
-struct RunFillState
+# ---- continuing boundary fill engine (high-oversampling fast path) ----
+# The continuing counterpart of `_generate_boundary!`: at high oversampling splat-fills one
+# chip run per store instead of paying a permute per W samples (see kernel.jl). Because the
+# boundary arithmetic is EXACT, the carried state is just `(c, r)` — the table chip index
+# and the fractional chip phase — and continuation is byte-identical to one big fill for any
+# chunking (the old run-fill's `(c, acc, pos)` approximate-DDA state and its documented
+# multi-fill drift are gone). The store width `SW` / long-run `EXTRAS` flag are type
+# parameters so `fill_continue!` calls the specialised kernel statically (0-alloc); like the
+# old `Val{NI}` they are fixed at construction, but they are a pure store-width choice — any
+# variant is exact for any rate.
+struct BoundaryState
     c::Int                    # current table chip index
-    acc::Int                  # chip-start fractional phase (delta & mask)
-    pos::Int                  # samples of the current chip already emitted
+    r::_RemT                  # fractional chip phase (< 2^_B)
 end
 
-struct FillEngineRunFill{NI}
-    chips::Vector{Int8}
+struct FillEngineBoundary{SW,EXTRAS}
+    padded::Vector{Int8}
     L::Int
-    ff::Int             # samples-per-chip in _RUNFILL_FP fixed point
-    ni::Int             # padded inner count (used by the NI==0 generic path)
+    step_num::Int
     c0::Int             # initial table chip index (for fill_state)
-    acc0::Int           # initial chip-start fractional phase (for fill_state)
-    pos0::Int           # initial in-chip sample offset (for fill_state)
+    r0::_RemT           # initial fractional chip phase (for fill_state)
 end
 
-function FillEngineRunFill(table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int,
-                           rem0::_RemT = _RemT(0))
-    ni = _runfill_ni(step_num)
-    NI = ni <= _RUNFILL_MAX_NI ? ni : 0      # 0 ⇒ generic kernel (runtime `ni`)
-    acc, pos = _runfill_seed(step_num, step_den, rem0)
-    FillEngineRunFill{NI}(table.chips, table.length, _runfill_freqfix(step_num),
-                          ni, mod(phase_offset, table.length), acc, pos)
+function FillEngineBoundary(table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int,
+                            rem0::_RemT = _RemT(0))
+    c0 = Int(mod(Int64(rem0) >> _B + phase_offset, table.length))
+    r0 = _RemT(Int64(rem0) & Int64(step_den - 1))
+    m = _STEP_DEN ÷ step_num
+    if m <= 14
+        FillEngineBoundary{16,false}(table.padded, table.length, step_num, c0, r0)
+    elseif m <= 30
+        FillEngineBoundary{32,false}(table.padded, table.length, step_num, c0, r0)
+    elseif m <= 62
+        FillEngineBoundary{64,false}(table.padded, table.length, step_num, c0, r0)
+    else
+        FillEngineBoundary{64,true}(table.padded, table.length, step_num, c0, r0)
+    end
 end
 
-@inline fill_state(eng::FillEngineRunFill) = RunFillState(eng.c0, eng.acc0, eng.pos0)
+@inline fill_state(eng::FillEngineBoundary) = BoundaryState(eng.c0, eng.r0)
 
-function fill_continue!(out::AbstractVector{<:Integer}, eng::FillEngineRunFill{NI}, st::RunFillState) where {NI}
-    c, acc, pos = NI == 0 ?
-        _runfill_seg_generic!(out, eng.chips, eng.L, eng.ff, eng.ni, st.c, st.acc, st.pos) :
-        _runfill_seg!(out, eng.chips, eng.L, eng.ff, st.c, st.acc, st.pos, Val(NI))
-    return RunFillState(c, acc, pos)
+function fill_continue!(out::AbstractVector{<:Integer}, eng::FillEngineBoundary{SW,EXTRAS},
+                        st::BoundaryState) where {SW,EXTRAS}
+    SN = Int64(eng.step_num)
+    _boundary_fill!(out, eng.padded, eng.L, SN, st.c, Int64(st.r), Val(SW), Val(EXTRAS))
+    # advance the state by exactly length(out) samples, arithmetically (exact)
+    tot = Int64(st.r) + Int64(length(out)) * SN
+    BoundaryState(Int(mod(Int64(st.c) + (tot >> _B), eng.L)), _RemT(tot & Int64(_STEP_DEN - 1)))
 end
 
 # Union over the backend fill engines (Portable is the W=1 degenerate phase engine: window
 # emit + advance are scalar but correct).
-const FillEngineAny = Union{FillEngine512,FillEnginePhase,FillEngineRunFill}
+const FillEngineAny = Union{FillEngine512,FillEnginePhase,FillEngineBoundary}
 
 # ---- factory: build the right backend fill engine from a step ratio + phase ----
 function make_fill_engine(table::CodeTable, step_num::Integer, step_den::Integer;
@@ -306,11 +309,10 @@ function make_fill_engine(table::CodeTable, step_num::Integer, step_den::Integer
     (0 ≤ rem0 < step_den) ||
         throw(ArgumentError("need 0 ≤ rem0 < step_denominator (fractional sub-chip offset)"))
     sn = Int(step_num); sd = Int(step_den); ph = Int(phase); r0 = _RemT(rem0)
-    if _use_runfill(sn, sd, backend)
-        # High oversampling: broadcast-fill runs (see `_generate_runfill!`) instead of paying
-        # a permute per window. Same windowed-length requirement as the AVX2/NEON permute.
-        backend isa Union{AVX2,Neon} && _check_windowed_length(table, backend)
-        FillEngineRunFill(table, sn, sd, ph, r0)
+    if _use_boundary(sn, sd, backend)
+        # High oversampling: splat-fill chip runs (see `_generate_boundary!`) instead of
+        # paying a permute per window. No windowed-length requirement (no in-register window).
+        FillEngineBoundary(table, sn, sd, ph, r0)
     elseif backend isa AVX512
         FillEngine512(table, sn, sd, ph, r0)
     elseif backend isa Union{AVX2,Neon}

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -519,12 +519,17 @@ function _boundary_fill!(out, padded, L::Int, SN::Int64, c0::Int, r0::Int64,
 end
 
 # Store width: smallest power of two ≥ m+2 (a run is m or m+1 samples, +1 slack so one
-# store always covers a run), clamped to [16, 64]. Beyond m = 62 the `EXTRAS` variant adds
+# store always covers a run), clamped to [8, 64]. Beyond m = 62 the `EXTRAS` variant adds
 # the strided interior stores. Purely a store-width choice — every variant is exact for
-# every rate, so this ladder (unlike the old `Val{NI}` one) cannot change the output.
+# every rate, so this ladder (unlike the old `Val{NI}` one) cannot change the output. The
+# SW = 8 rung matters on store-bandwidth-limited cores (CI runners): at m ≈ 5 a 16-wide
+# store is 3.3× write amplification vs 8-wide's 1.6× (measured 1.4–1.6× on the ubuntu
+# benchmark's GPSL1CA @ 5 MHz row).
 @inline function _boundary_dispatch!(out, padded, L::Int, SN::Int64, c0::Int, r0::Int64)
     m = _STEP_DEN ÷ Int(SN)
-    if m <= 14
+    if m <= 6
+        _boundary_fill!(out, padded, L, SN, c0, r0, Val(8), Val(false))
+    elseif m <= 14
         _boundary_fill!(out, padded, L, SN, c0, r0, Val(16), Val(false))
     elseif m <= 30
         _boundary_fill!(out, padded, L, SN, c0, r0, Val(32), Val(false))

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -90,8 +90,8 @@ function generate_code!(out::AbstractVector{<:Integer}, table::CodeTable,
         throw(ArgumentError("need 0 < step_numerator ≤ step_denominator (must oversample, chips/sample ≤ 1)"))
     (0 ≤ rem0 < step_denominator) ||
         throw(ArgumentError("need 0 ≤ rem0 < step_denominator (fractional sub-chip offset)"))
-    if _use_runfill(Int(step_numerator), Int(step_denominator), backend, length(out))
-        _generate_runfill!(out, table, Int(step_numerator), Int(step_denominator), Int(phase), _RemT(rem0))
+    if out isa AbstractVector{Int8} && _use_boundary(Int(step_numerator), Int(step_denominator), backend)
+        _generate_boundary!(out, table, Int(step_numerator), Int(step_denominator), Int(phase), _RemT(rem0))
     else
         _generate!(out, table, Int(step_numerator), Int(step_denominator), Int(phase), backend, _RemT(rem0))
     end
@@ -349,256 +349,216 @@ end
     out
 end
 
-# ── run-length fill (high-oversampling fast path) ─────────────────────────────────────
-# When the chip rate is far below the sample rate (`m = step_den ÷ step_num` samples per
-# chip is large), the windowed permute is wasteful: a whole W-sample window covers only
-# `W/m` distinct chips, yet the permute recomputes all W lanes. The original `gen_code!`
-# wins here by *broadcast-filling* runs of identical chips — store-bandwidth bound, no
-# per-sample lookup. We do the same directly on the baked ±1 table.
+# ── boundary fill (high-oversampling fast path) ────────────────────────────────────────
+# When the chip rate is far below the sample rate (`m = 2^_B ÷ step_num` samples per chip
+# is large), the windowed permute is wasteful: a W-sample block covers only W/m distinct
+# chips, yet the permute recomputes all W lanes. Here we iterate over CHIPS instead: within
+# a segment anchored at sample `pos` (chip `c0`, fractional chip phase `r0 < 2^_B`), chip
+# `c0 + i` starts at, exactly,
+#     pos + ⌈(i·2^_B − r0) / step_num⌉
+# and is emitted as ONE splat store of width `SW = nextpow2(m+2) ∈ {16,32,64}` at that
+# boundary (a run is ≤ m+1 < SW samples, and stores are issued left-to-right, so the next
+# chip's store overwrites the overhang — the same trick as the original `gen_code!`).
+# Runs longer than SW (m > SW−2, only possible at SW = 64) get extra SW-strided interior
+# stores (the `EXTRAS` variant). Segments re-anchor `(c0, r0, pos)` once per code period,
+# so the chip-index wrap costs nothing per chip.
 #
-# DDA. Samples-per-chip `2^_B / step_num` is held in `_RUNFILL_FP`-bit fixed point as
-# `freqfix = round(2^_B · 2^_RUNFILL_FP / step_num)`; a running `delta += freqfix` gives the
-# next chip boundary as `delta >> _RUNFILL_FP`. This is a single short carried add (the store
-# positions pipeline at memory bandwidth) — an exact multiplicative-inverse `base(c)` or a
-# Bresenham remainder recurrence both measured ~2–3× slower (extra multiply / a serialising
-# per-chip compare). The cost is a *rounding* approximation: the boundary can differ from the
-# permute path's exact `ceil(c·2^_B/step_num)` by ≤1–2 samples, but only after ~10⁵ chips —
-# for any single fill the output is byte-identical, and over a long continued stream the
-# drift stays at a couple of samples (same order as the permute path's own documented rate-
-# quantisation drift, and well inside the integer-chip-phase rounding the plan already makes).
-#
-# Like the original's worker, each chip stores a compile-time-fixed `NI ≥ run length` copies
-# (run is `m` or `m+1`) and the next chip's `base` overwrites the ≤ `NI−run` overhang; the
-# main loop is bounds-counted (no per-chip branch) and a scalar tail finishes the remainder.
-# Continuation across fills carries `(chip, acc, pos)`: the table chip index, the fractional
-# accumulator `acc = delta & mask` (chip-start phase), and `pos` = samples of the current
-# chip already emitted (so a fill may resume mid-run). `delta` is re-seeded from `acc` each
-# fill, so it stays bounded by `N·2^_RUNFILL_FP` (no unbounded growth across a long stream).
+# The ceil-division is EXACT: for non-power-of-two `step_num` it uses the (64+ℓ)-bit
+# round-up magic reciprocal `magic = ⌈2^(64+ℓ)/step_num⌉` (ℓ = ⌊log₂ step_num⌋), which by
+# the classical Granlund–Montgomery bound reproduces ⌈d/step_num⌉ for EVERY dividend
+# d < 2^64 — far above the ≤ L·2^_B < 2^50 a segment can produce. Power-of-two rates are a
+# plain shift. So the output is byte-identical to the permute kernels / Portable oracle for
+# any fill length and any continuation split — unlike the `freqfix` run-fill this replaces,
+# whose rounded reciprocal drifted ~1–2 samples per ~10⁵ chips and needed a `_RUNFILL_MAXFILL`
+# segmentation cap and a `Val{NI}` store-width ladder. One boundary calculation is one
+# independent multiply-high (no loop-carried arithmetic, unrolled 4×), one chip value is one
+# byte load + broadcast, so the steady state is ~1 store per chip at store throughput. There
+# is no vector arithmetic at all — the splat stores are plain unaligned SIMD.jl stores — so
+# this ONE kernel serves every backend (and any table length; no `_check_windowed_length`).
 
-const _RUNFILL_FP   = 40                       # fractional bits for samples-per-chip
-const _RUNFILL_MASK = (Int(1) << _RUNFILL_FP) - 1
-# Cap a single core call so `delta ≈ N·2^_RUNFILL_FP` stays in Int64 (2^22·2^40 = 2^62);
-# longer buffers are processed in back-to-back segments via the (exact) carried state.
-const _RUNFILL_MAXFILL = 1 << 22
-const _RUNFILL_MAX_NI  = 64                     # largest `Val`-specialised inner count
+# ⌊log₂ SN⌋ and the round-up reciprocal; magic == 0 marks the power-of-two shift path.
+@inline _boundary_lg(SN::Int64) = 63 - leading_zeros(SN)
+@inline _boundary_magic(SN::Int64, lg::Int) =
+    SN == Int64(1) << lg ? UInt64(0) :
+        UInt64((((UInt128(1) << (64 + lg)) + UInt128(SN) - 1) ÷ UInt128(SN)) % UInt128)
 
-# samples-per-chip in `_RUNFILL_FP` fixed point. Int128 intermediate: 2^_B·2^FP = 2^70.
-@inline _runfill_freqfix(step_num::Int) =
-    Int((Int128(_STEP_DEN) << _RUNFILL_FP + (step_num >> 1)) ÷ step_num)
+# Branch-free exact ⌈d/SN⌉ for d ≥ 1 via ⌊(d−1)·magic / 2^(64+lg)⌋ + 1. `% UInt64` avoids
+# the checked-conversion branch and `lg & 31` makes the shift range provable (lg ≤ _B = 30),
+# so the whole thing is one `mulx` + one shift in the hot loop.
+@inline _boundary_ceildiv(d::Int64, lg::Int, magic::UInt64) =
+    magic == 0 ? Int((d - 1) >>> (lg & 31)) + 1 :
+                 Int((((widemul((d - 1) % UInt64, magic) >> 64) % UInt64) >>> (lg & 31)) % Int64) + 1
 
-# Round the fixed inner-store count up to a power-of-two SIMD store width, so LLVM emits a single
-# wide broadcast store rather than the vector-plus-scalar-remainder sequence an odd width forces.
-# The extra over-store (< 2× the run length) is harmless — the next chip's `base` overwrites the
-# overhang — and the clean width is a clear net win: measured ~1.4–1.7× on the mid-range
-# non-power-of-two runs (m ∈ [17,24], where the old ladder left widths like 18/20/24/25), and
-# neutral where the run is already a power of two (m = 8,16,32,64). Above the `Val` ladder (x>64)
-# the runtime-`NI` generic kernel takes over, so leave x unpadded there. min 4 so the `Val`
-# dispatcher always has a branch.
-@inline function _runfill_pad(x::Int)
-    x <= 4  ? 4  :
-    x <= 8  ? 8  :
-    x <= 16 ? 16 :
-    x <= 32 ? 32 :
-    x <= 64 ? 64 : x
+# Scalar leftover (< SW samples): plain per-sample DDA walk from `(c0, r0)` at `pos`.
+@inline function _boundary_scalar_tail!(out, padded, L::Int, SN::Int64, c0::Int, r0::Int64, pos::Int)
+    mask = Int64(_STEP_DEN - 1)
+    @inbounds while pos < length(out)
+        out[pos + 1] = padded[c0 + 1]
+        r = r0 + SN
+        c0 += Int(r >> _B)
+        r0 = r & mask
+        c0 >= L && (c0 -= L)
+        pos += 1
+    end
+    nothing
 end
 
-# Padded inner count for a step (samples/chip ≈ `2^_B / step_num`, run length `m` or `m+1`).
-@inline function _runfill_ni(step_num::Int)
-    m = _STEP_DEN ÷ step_num
-    _runfill_pad(_STEP_DEN % step_num > 0 ? m + 1 : m)
-end
-
-# Fill `out[1:N]` (N ≤ _RUNFILL_MAXFILL) continuing from carried state `(c, acc, pos)`:
-# `c` = table chip index, `acc` = chip-c start phase (delta & mask), `pos` = samples of chip
-# c already emitted. Returns the carried state advanced by N samples. `ff = freqfix`.
-@inline function _runfill_core!(out, chips, L::Int, ff::Int, c::Int, acc::Int, pos::Int, ::Val{NI}) where {NI}
-    N = length(out); FP = _RUNFILL_FP; mask = _RUNFILL_MASK
-    @inbounds begin
-        delta = acc                          # base = delta >> FP = 0 (acc < 2^FP)
-        # head: finish the current chip's run (its first `pos` samples were emitted before)
-        rem_run = ((delta + ff) >> FP) - pos
-        hi = ifelse(rem_run < N, rem_run, N)
-        v = chips[c + 1]
-        for j = 1:hi
-            out[j] = v
-        end
-        hi < rem_run && return (c, acc, pos + N)     # buffer ended inside the current chip
-        # bias `delta` by `pos<<FP` (zero low bits ⇒ `delta & mask` unchanged) so that
-        # `delta >> FP` reads as the buffer position directly (no per-store subtraction).
-        delta += ff - (pos << FP)
-        base = delta >> FP                   # = rem_run (first full-chip boundary)
-        c += 1; c >= L && (c -= L)
-        # main: counted full chips with Val over-store (no per-chip bound check). Conservative
-        # count: base(k)+NI ≤ N is implied by k ≤ (N-NI-1)·2^FP / ff (base(k) < 1 + k·ff/2^FP).
-        rem_samps = N - base
-        nmc = rem_samps > NI ? Int(((Int128(rem_samps - NI)) << FP) ÷ ff) : 0
-        done = 0
-        while done < nmc
-            seg = L - c
-            seg > nmc - done && (seg = nmc - done)
-            for t = 0:seg-1
-                vv = chips[c + t + 1]
-                for j = 1:NI
-                    out[base + j] = vv
+# Core boundary fill from continuation state `(c0, r0)` (chip index, fractional chip phase).
+# Requires a pointer-compatible contiguous Int8 `out` (the same contract as the permute
+# kernels' `VecRange` stores). Writes exactly `length(out)` samples; the caller derives the
+# advanced state arithmetically (see `fill_continue!`).
+function _boundary_fill!(out, padded, L::Int, SN::Int64, c0::Int, r0::Int64,
+                         ::Val{SW}, ::Val{EXTRAS}) where {SW,EXTRAS}
+    lg = _boundary_lg(SN)
+    magic = _boundary_magic(SN, lg)
+    num = length(out)
+    pos = 0
+    GC.@preserve out padded begin
+        po = pointer(out); pp = pointer(padded)
+        @inbounds while pos + SW <= num
+            nc = L - c0                                     # chips before the code wraps
+            # last chip i whose boundary jn keeps the SW-wide store in bounds (jn + SW ≤ num)
+            ibound = (Int64(num - SW - pos) * SN + r0) >> _B
+            nlim = ibound < nc ? Int(ibound) : nc
+            vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + 1)), po + pos, nothing)
+            jn = pos
+            i = 1
+            if !EXTRAS
+                # a run is ≤ m+1 < SW: exactly one store per chip, at its own boundary
+                if magic == 0                               # power-of-two rate: shift only
+                    d = (Int64(1) << _B) - r0 - 1
+                    pos1 = pos + 1
+                    while i <= nlim
+                        jn = pos1 + Int(d >>> (lg & 31))
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1)), po + jn, nothing)
+                        d += Int64(1) << _B
+                        i += 1
+                    end
+                else
+                    # unrolled 4×: four INDEPENDENT multiply-highs per iteration
+                    d = (Int64(1) << _B) - r0
+                    while i + 3 <= nlim
+                        j1 = pos + _boundary_ceildiv(d, lg, magic)
+                        j2 = pos + _boundary_ceildiv(d + (Int64(1) << _B), lg, magic)
+                        j3 = pos + _boundary_ceildiv(d + (Int64(2) << _B), lg, magic)
+                        j4 = pos + _boundary_ceildiv(d + (Int64(3) << _B), lg, magic)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1)), po + j1, nothing)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 2)), po + j2, nothing)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 3)), po + j3, nothing)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 4)), po + j4, nothing)
+                        jn = j4
+                        d += Int64(4) << _B
+                        i += 4
+                    end
+                    while i <= nlim
+                        jn = pos + _boundary_ceildiv(d, lg, magic)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1)), po + jn, nothing)
+                        d += Int64(1) << _B
+                        i += 1
+                    end
                 end
-                delta += ff; base = delta >> FP
+            else
+                # runs can exceed SW (m > SW−2): carry the current chip and add SW-strided
+                # interior stores up to the next boundary
+                vcur = Vec{SW,Int8}(unsafe_load(pp, c0 + 1))
+                jcur = pos
+                while i <= nlim
+                    jn = pos + _boundary_ceildiv((Int64(i) << _B) - r0, lg, magic)
+                    t = jcur + SW
+                    while t < jn
+                        vstore(vcur, po + t, nothing)
+                        t += SW
+                    end
+                    vcur = Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1))
+                    vstore(vcur, po + jn, nothing)
+                    jcur = jn
+                    i += 1
+                end
             end
-            c += seg; done += seg
-            c >= L && (c -= L)
-        end
-        # tail: bounds-checked, one run at a time, until the buffer is full
-        while base < N
-            v3 = chips[c + 1]
-            nb = (delta + ff) >> FP
-            hit = ifelse(nb < N, nb, N)
-            for j = base+1:hit
-                out[j] = v3
+            if nlim == nc                                   # clean code wrap: re-anchor
+                r0 = r0 + Int64(jn - pos) * SN - (Int64(nc) << _B)
+                c0 = 0
+                pos = jn
+                continue
             end
-            nb > N && return (c, delta & mask, N - base)   # buffer ended mid-run
-            delta += ff; base = nb
-            c += 1; c >= L && (c -= L)
-        end
-        return (c, delta & mask, 0)          # ended exactly on a chip boundary
-    end
-end
-
-# Runtime-`NI` generic kernel for oversampling above the `Val`-specialised ladder.
-@inline function _runfill_core_generic!(out, chips, L::Int, ff::Int, c::Int, acc::Int, pos::Int, NI::Int)
-    N = length(out); FP = _RUNFILL_FP; mask = _RUNFILL_MASK
-    @inbounds begin
-        delta = acc
-        rem_run = ((delta + ff) >> FP) - pos
-        hi = ifelse(rem_run < N, rem_run, N)
-        v = chips[c + 1]
-        @simd ivdep for j = 1:hi
-            out[j] = v
-        end
-        hi < rem_run && return (c, acc, pos + N)
-        delta += ff - (pos << FP)
-        base = delta >> FP
-        c += 1; c >= L && (c -= L)
-        while base < N
-            v3 = chips[c + 1]
-            nb = (delta + ff) >> FP
-            hit = ifelse(nb < N, nb, N)
-            @simd ivdep for j = base+1:hit
-                out[j] = v3
+            # wind-down: the remaining chips' stores must clamp at `num`; at most SW−1
+            # samples (the final partial store) fall back to scalar byte stores.
+            jcur = jn
+            vcur = Vec{SW,Int8}(unsafe_load(pp, c0 + i))
+            while true
+                jnx = i <= nc ? pos + _boundary_ceildiv((Int64(i) << _B) - r0, lg, magic) :
+                                pos + _boundary_ceildiv((Int64(nc) << _B) - r0, lg, magic)
+                stop = jnx < num ? jnx : num
+                t = jcur
+                while t + SW <= num && t < stop
+                    vstore(vcur, po + t, nothing)
+                    t += SW
+                end
+                if t < stop
+                    x = vcur[1]
+                    while t < stop
+                        unsafe_store!(po, x, t + 1)
+                        t += 1
+                    end
+                end
+                stop >= num && return out
+                if i >= nc                                  # code wrapped inside wind-down
+                    r0 = r0 + Int64(jnx - pos) * SN - (Int64(nc) << _B)
+                    c0 = 0
+                    pos = jnx
+                    break                                   # rare; outer loop re-enters
+                end
+                vcur = Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1))
+                jcur = jnx
+                i += 1
             end
-            nb > N && return (c, delta & mask, N - base)
-            delta += ff; base = nb
-            c += 1; c >= L && (c -= L)
         end
-        return (c, delta & mask, 0)
+        pos < num && _boundary_scalar_tail!(out, padded, L, SN, c0, r0, pos)
     end
+    out
 end
 
-# Fill `out` (any length) continuing from `(c, acc, pos)`, segmenting into ≤ _RUNFILL_MAXFILL
-# chunks so the per-call `delta` cannot overflow. `NI` is a compile-time constant (the inner
-# store trip count), so the `Val{NI}` kernel dispatches statically — 0 allocations per call.
-function _runfill_seg!(out, chips, L::Int, ff::Int, c::Int, acc::Int, pos::Int, ::Val{NI}) where {NI}
-    N = length(out)
-    if N <= _RUNFILL_MAXFILL
-        return _runfill_core!(out, chips, L, ff, c, acc, pos, Val(NI))
+# Store width: smallest power of two ≥ m+2 (a run is m or m+1 samples, +1 slack so one
+# store always covers a run), clamped to [16, 64]. Beyond m = 62 the `EXTRAS` variant adds
+# the strided interior stores. Purely a store-width choice — every variant is exact for
+# every rate, so this ladder (unlike the old `Val{NI}` one) cannot change the output.
+@inline function _boundary_dispatch!(out, padded, L::Int, SN::Int64, c0::Int, r0::Int64)
+    m = _STEP_DEN ÷ Int(SN)
+    if m <= 14
+        _boundary_fill!(out, padded, L, SN, c0, r0, Val(16), Val(false))
+    elseif m <= 30
+        _boundary_fill!(out, padded, L, SN, c0, r0, Val(32), Val(false))
+    elseif m <= 62
+        _boundary_fill!(out, padded, L, SN, c0, r0, Val(64), Val(false))
+    else
+        _boundary_fill!(out, padded, L, SN, c0, r0, Val(64), Val(true))
     end
-    o = 0
-    while o < N
-        seg = min(N - o, _RUNFILL_MAXFILL)
-        c, acc, pos = _runfill_core!(view(out, o+1:o+seg), chips, L, ff, c, acc, pos, Val(NI))
-        o += seg
-    end
-    (c, acc, pos)
+    nothing
 end
 
-# Generic (runtime-`NI`) segmented wrapper for oversampling above the `Val` ladder.
-function _runfill_seg_generic!(out, chips, L::Int, ff::Int, ni::Int, c::Int, acc::Int, pos::Int)
-    N = length(out)
-    if N <= _RUNFILL_MAXFILL
-        return _runfill_core_generic!(out, chips, L, ff, c, acc, pos, ni)
-    end
-    o = 0
-    while o < N
-        seg = min(N - o, _RUNFILL_MAXFILL)
-        c, acc, pos = _runfill_core_generic!(view(out, o+1:o+seg), chips, L, ff, c, acc, pos, ni)
-        o += seg
-    end
-    (c, acc, pos)
+# One-shot boundary fill from an integer chip phase + fractional sub-chip offset `rem0`
+# (the same seeding as the permute kernels; byte-identical output).
+function _generate_boundary!(out, table::CodeTable, step_num::Int, step_den::Int,
+                             phase_offset::Int, rem0::_RemT = _RemT(0))
+    c0 = Int(mod(Int64(rem0) >> _B + phase_offset, table.length))
+    r0 = Int64(rem0) & Int64(step_den - 1)
+    _boundary_dispatch!(out, table.padded, table.length, Int64(step_num), c0, r0)
+    out
 end
 
-# Statically dispatch a runtime padded `ni` to the matching `Val{NI}` run-fill kernel via an
-# explicit branch ladder (`i = 4:_RUNFILL_MAX_NI`); above the ladder the runtime-`NI` generic
-# kernel takes over. Lifting a runtime `Val(ni)` instead would box once per call, so this keeps
-# the one-shot path 0-alloc — the same trick (and ladder range) as `dispatch_sample_code_worker!`
-# for the original `gen_code!`. `_runfill_ni` floors at 4, so the ladder never sees 1..3.
-@generated function _runfill_seg_dispatch!(out, chips, L::Int, ff::Int, ni::Int,
-                                           c::Int, acc::Int, pos::Int)
-    branches = [
-        :(ni == $i && return _runfill_seg!(out, chips, L, ff, c, acc, pos, Val($i)))
-        for i = 4:_RUNFILL_MAX_NI
-    ]
-    quote
-        $(branches...)
-        return _runfill_seg_generic!(out, chips, L, ff, ni, c, acc, pos)
-    end
-end
-
-# One-shot run-fill from chip phase, sample 0 (acc = mask gives the `ceil`-boundary rounding
-# that matches the permute path; pos = 0). Dispatches to the `Val{NI}`-specialised kernel
-# allocation-free; the *continuing* generator stays 0-alloc by carrying `NI` in its type
-# (see `CodeGeneratorRunFill`).
-function _generate_runfill!(out, table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int,
-                            rem0::_RemT = _RemT(0))
-    ff = _runfill_freqfix(step_num); ni = _runfill_ni(step_num)
-    c = mod(phase_offset, table.length)
-    acc, pos = _runfill_seed(step_num, step_den, rem0)
-    _runfill_seg_dispatch!(out, table.chips, table.length, ff, ni, c, acc, pos)
-end
-
-# Seed the run-fill carried state `(acc, pos)` for a fractional sub-chip start offset `rem0`.
-#
-# Run-fill walks the chip boundaries with a `delta += ff` accumulator (`ff ≈ 2^_B·2^FP/step_num`
-# samples-per-chip in `_RUNFILL_FP` fixed point), so its chip-c boundary is `(delta_0 +
-# (c+1)·ff) >> FP`. With the integer-phase seed (`acc = mask, pos = 0`) that reproduces the
-# permute path's exact `ceil(c·2^_B / step_num)` boundaries. A fractional start offset shifts
-# every exact boundary EARLIER by `rem0 / step_num` samples (the boundary is
-# `ceil((c·2^_B − rem0)/step_num)`), so we bias the initial accumulator by the same amount in
-# sample-FP units: `delta_offset = round(rem0·ff / 2^_B) ≈ rem0·2^FP/step_num`. The biased
-# `seed = mask − delta_offset` is split into the in-FP fractional part `acc = seed mod 2^FP`
-# and the whole-sample carry `pos = −(seed − acc) >> FP` (samples of the first chip already
-# emitted). rem0 = 0 ⇒ `(mask, 0)`, byte-identical to the original.
-@inline function _runfill_seed(step_num::Int, step_den::Int, rem0::_RemT)
-    rem0 == _RemT(0) && return (_RUNFILL_MASK, 0)
-    ff = _runfill_freqfix(step_num)
-    delta_offset = Int((Int128(rem0) * ff) >> _B)       # rem0·ff/2^_B  (sample-FP units)
-    seed = _RUNFILL_MASK - delta_offset
-    acc  = mod(seed, Int(1) << _RUNFILL_FP)             # fractional part in [0, 2^FP)
-    pos  = -((seed - acc) >> _RUNFILL_FP)               # whole first-chip samples already emitted
-    (acc, pos)
-end
-
-# Pick the run-fill path when there are at least `_runfill_min_m` samples per chip. The
-# threshold is the per-chip count where broadcast-fill overtakes the windowed permute.
-# The split-constant permute kernels are faster, which RAISES the ideal crossover on fast
-# hardware (a Zen 5 desktop wants AVX-512 ≈ 8, AVX2 ≈ 6). But the crossover is strongly
-# hardware-dependent: on the ubuntu-latest CI runner, run-fill still beats the (now faster)
-# AVX2 permute from m = 3, so bumping the AVX2 threshold to 6 REGRESSED the m ∈ {3,4,5} cases
-# there (GPSL1CA@5MHz, GPSL5@40MHz, …). Since a single constant can't be optimal on both, we
-# keep the conservative #69-validated values — the permute speedup still applies unconditionally
-# below these thresholds (the common low-OSR cases, e.g. m = 2), and no case regresses vs #69.
-# The other backends: NEON `tbl1` (Apple-Silicon single-window v2) and Portable are unchanged.
-# Short fills (N-aware overload below): permute pays a fixed init cost vs run-fill's ~15 ns
-# freqfix divide, an edge ∝ 1/N that pulls the AVX-512 crossover to lower m for tiny N. Only the
-# one-shot `generate_code!` knows the fill length, so only it uses the N-aware overload; the
-# continuing fill engine fixes its kernel at construction (no N yet), so it uses the steady-state
-# threshold — correct for its typical large-epoch fills.
-@inline _runfill_min_m(::AVX512)   = 7
-@inline _runfill_min_m(::AVX2)     = 3
-@inline _runfill_min_m(::Neon)     = 3
-@inline _runfill_min_m(::Portable) = 2
-# N-aware overload (one-shot fills): lower the threshold for short fills. Only AVX-512's
-# permute is fast enough for this to matter; the others fall back to their steady threshold.
-@inline _runfill_min_m(be::AVX512, N::Int) = N < 1024 ? 4 : N < 4096 ? 5 : _runfill_min_m(be)
-@inline _runfill_min_m(be::Backend, ::Int) = _runfill_min_m(be)
-@inline _use_runfill(step_num::Int, step_den::Int, backend::Backend) =          # continuing
-    step_den ÷ step_num >= _runfill_min_m(backend)
-@inline _use_runfill(step_num::Int, step_den::Int, backend::Backend, N::Int) =  # one-shot (N-aware)
-    step_den ÷ step_num >= _runfill_min_m(backend, N)
+# Pick the boundary fill when there are at least `_boundary_min_m` samples per chip. The
+# crossover is where one W-lane permute block (cost ≈ flat per block) equals ~W/m boundary
+# stores (cost ≈ flat per chip), so it scales with the backend's block width — wider
+# vectors amortise the permute over more samples and push the switch to higher m. Values
+# are the measured curve crossings (Zen 5 AVX-512: boundary overtakes the split-constant
+# permute at m ≈ 10; AVX2/NEON anchored to the #69/#97 CI + Apple-Silicon data for the
+# narrower blocks). Near the crossover both kernels are within ~15 % of each other, so the
+# exact values are uncritical — and since both kernels are EXACT and N-independent, the
+# choice affects only speed, never output (the old N-aware short-fill overload is gone:
+# neither kernel has a meaningful setup cost).
+@inline _boundary_min_m(::AVX512)   = 10
+@inline _boundary_min_m(::AVX2)     = 4
+@inline _boundary_min_m(::Neon)     = 3
+@inline _boundary_min_m(::Portable) = 2
+@inline _use_boundary(step_num::Int, step_den::Int, backend::Backend) =
+    step_den ÷ step_num >= _boundary_min_m(backend)

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -376,6 +376,11 @@ end
 # is no vector arithmetic at all — the splat stores are plain unaligned SIMD.jl stores — so
 # this ONE kernel serves every backend (and any table length; no `_check_windowed_length`).
 
+# Boundary-step instruction selection: x86 favours the accumulated add/adc product,
+# aarch64 the independent `umulh`s (see the two branches in `_boundary_fill!`). Both are
+# bit-identical; compile-time constant, so the dead branch is eliminated.
+const _BOUNDARY_ACCUM = Sys.ARCH in (:x86_64, :i686)
+
 # ⌊log₂ SN⌋ and the round-up reciprocal; magic == 0 marks the power-of-two shift path.
 @inline _boundary_lg(SN::Int64) = 63 - leading_zeros(SN)
 @inline _boundary_magic(SN::Int64, lg::Int) =
@@ -434,13 +439,14 @@ function _boundary_fill!(out, padded, L::Int, SN::Int64, c0::Int, r0::Int64,
                         d += Int64(1) << _B
                         i += 1
                     end
-                else
-                    # ACCUMULATED 128-bit product: P_i = (d_i−1)·magic advances by the
+                elseif _BOUNDARY_ACCUM
+                    # x86: ACCUMULATED 128-bit product. P_i = (d_i−1)·magic advances by the
                     # constant 2^_B·magic, kept as a manual (hi, lo) pair so it lowers to
-                    # add/adc (LLVM's Int128 lowering is worse) — the boundary is
-                    # hi >> lg, so each chip costs one add/adc + shift instead of a
-                    # multiply-high (bit-identical to `_boundary_ceildiv`; measured
-                    # ~1.15–1.2× over the mulx form on Zen 5).
+                    # add/adc (LLVM's Int128 lowering is worse) — the boundary is hi >> lg,
+                    # so each chip costs one add/adc + shift instead of a multiply-high.
+                    # Bit-identical to `_boundary_ceildiv`; measured ~1.15–1.2× over the
+                    # mulx form on Zen 5 and it recovered the CI AVX2 GPSL1CA @ 5 MHz row
+                    # (0.68 → 0.95 vs run-fill).
                     Clo = (magic << _B) % UInt64
                     Chi = (magic >>> (64 - _B)) % UInt64
                     P = widemul((((Int64(1) << _B) - r0 - 1)) % UInt64, magic)
@@ -452,6 +458,31 @@ function _boundary_fill!(out, padded, L::Int, SN::Int64, c0::Int, r0::Int64,
                         vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1)), po + jn, nothing)
                         lo, c = Base.add_with_overflow(lo, Clo)
                         hi = hi + Chi + c
+                        i += 1
+                    end
+                else
+                    # aarch64: four INDEPENDENT multiply-highs per iteration (`umulh` is
+                    # cheap on Apple Silicon; the add/adc carry chain is what regressed the
+                    # macos benchmark rows from 1.2–1.4× back to ~0.8×, so the ISA picks
+                    # the form — output is bit-identical either way).
+                    d = (Int64(1) << _B) - r0
+                    while i + 3 <= nlim
+                        j1 = pos + _boundary_ceildiv(d, lg, magic)
+                        j2 = pos + _boundary_ceildiv(d + (Int64(1) << _B), lg, magic)
+                        j3 = pos + _boundary_ceildiv(d + (Int64(2) << _B), lg, magic)
+                        j4 = pos + _boundary_ceildiv(d + (Int64(3) << _B), lg, magic)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1)), po + j1, nothing)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 2)), po + j2, nothing)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 3)), po + j3, nothing)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 4)), po + j4, nothing)
+                        jn = j4
+                        d += Int64(4) << _B
+                        i += 4
+                    end
+                    while i <= nlim
+                        jn = pos + _boundary_ceildiv(d, lg, magic)
+                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1)), po + jn, nothing)
+                        d += Int64(1) << _B
                         i += 1
                     end
                 end
@@ -554,13 +585,13 @@ end
 # stores (cost ≈ flat per chip), so it scales with the backend's block width — wider
 # vectors amortise the permute over more samples and push the switch to higher m. Values
 # are the measured curve crossings (Zen 5 AVX-512: boundary overtakes the split-constant
-# permute at m ≈ 10; AVX2/NEON anchored to the #69/#97 CI + Apple-Silicon data for the
-# narrower blocks). Near the crossover both kernels are within ~15 % of each other, so the
+# permute at m ≈ 10; AVX2/NEON = 3, matching the old run-fill values — on the CI AVX2
+# runner the m ≈ 3.9 rows (GPSL5 @ 40 MHz) lose ~20 % when sent to the permute instead). Near the crossover both kernels are within ~15 % of each other, so the
 # exact values are uncritical — and since both kernels are EXACT and N-independent, the
 # choice affects only speed, never output (the old N-aware short-fill overload is gone:
 # neither kernel has a meaningful setup cost).
 @inline _boundary_min_m(::AVX512)   = 10
-@inline _boundary_min_m(::AVX2)     = 4
+@inline _boundary_min_m(::AVX2)     = 3
 @inline _boundary_min_m(::Neon)     = 3
 @inline _boundary_min_m(::Portable) = 2
 @inline _use_boundary(step_num::Int, step_den::Int, backend::Backend) =

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -435,25 +435,23 @@ function _boundary_fill!(out, padded, L::Int, SN::Int64, c0::Int, r0::Int64,
                         i += 1
                     end
                 else
-                    # unrolled 4×: four INDEPENDENT multiply-highs per iteration
-                    d = (Int64(1) << _B) - r0
-                    while i + 3 <= nlim
-                        j1 = pos + _boundary_ceildiv(d, lg, magic)
-                        j2 = pos + _boundary_ceildiv(d + (Int64(1) << _B), lg, magic)
-                        j3 = pos + _boundary_ceildiv(d + (Int64(2) << _B), lg, magic)
-                        j4 = pos + _boundary_ceildiv(d + (Int64(3) << _B), lg, magic)
-                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1)), po + j1, nothing)
-                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 2)), po + j2, nothing)
-                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 3)), po + j3, nothing)
-                        vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 4)), po + j4, nothing)
-                        jn = j4
-                        d += Int64(4) << _B
-                        i += 4
-                    end
+                    # ACCUMULATED 128-bit product: P_i = (d_i−1)·magic advances by the
+                    # constant 2^_B·magic, kept as a manual (hi, lo) pair so it lowers to
+                    # add/adc (LLVM's Int128 lowering is worse) — the boundary is
+                    # hi >> lg, so each chip costs one add/adc + shift instead of a
+                    # multiply-high (bit-identical to `_boundary_ceildiv`; measured
+                    # ~1.15–1.2× over the mulx form on Zen 5).
+                    Clo = (magic << _B) % UInt64
+                    Chi = (magic >>> (64 - _B)) % UInt64
+                    P = widemul((((Int64(1) << _B) - r0 - 1)) % UInt64, magic)
+                    lo = P % UInt64
+                    hi = (P >> 64) % UInt64
+                    pos1 = pos + 1
                     while i <= nlim
-                        jn = pos + _boundary_ceildiv(d, lg, magic)
+                        jn = pos1 + Int((hi >>> (lg & 31)) % Int64)
                         vstore(Vec{SW,Int8}(unsafe_load(pp, c0 + i + 1)), po + jn, nothing)
-                        d += Int64(1) << _B
+                        lo, c = Base.add_with_overflow(lo, Clo)
+                        hi = hi + Chi + c
                         i += 1
                     end
                 end

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -171,14 +171,14 @@ const _BACKENDS = (CL.Portable(),
         end
     end
 
-    @testset "high-oversampling run-fill path" begin
+    @testset "high-oversampling boundary-fill path" begin
         # At high oversampling `make_fill_engine` / `generate_code!` switch from the windowed
-        # permute to a broadcast run-fill (`_runfill_*`). Its approximate samples-per-chip DDA
-        # matches the exact `floor(step_num·n/2^_B)` fixed-point reference for any single fill
-        # (the rounding drift only reaches ≤1 sample after ~10⁶ chips — see the drift test
-        # below), so here it must be byte-identical. Sweep `m = samples/chip` across the
-        # `Val`-specialised ladder AND the `m > 64` generic kernel, with non-power-of-two
-        # rates (`m`/`m+1` mixed runs), several phases/lengths, and chunked continuation.
+        # permute to the boundary fill (`_boundary_*`), whose exact magic-reciprocal chip
+        # boundaries are byte-identical to the `floor(step_num·n/2^_B)` fixed-point reference
+        # for ANY fill length or continuation chunking. Sweep `m = samples/chip` across the
+        # store-width ladder (SW = 16/32/64) AND the `m > 62` long-run EXTRAS variant, with
+        # non-power-of-two rates (`m`/`m+1` mixed runs), several phases/lengths, and chunked
+        # continuation.
         rng = MersenneTwister(99)
         for L in (1023, 257, 64)
             chips = rand(rng, Int8[-1, 1], L); ct = CL.CodeTable(chips)
@@ -209,12 +209,35 @@ const _BACKENDS = (CL.Portable(),
         end
     end
 
+    @testset "boundary kernel forced: exact vs oracle across every regime" begin
+        # Drive `_generate_boundary!` DIRECTLY (bypassing the `_use_boundary` gate) so every
+        # store-width branch (SW = 16/32/64, EXTRAS), the power-of-two shift path and the
+        # magic-reciprocal path, code wraps, wind-down clamping and the < SW scalar tail are
+        # all exercised — even at rates the dispatcher would send to the permute kernels.
+        # The kernel is exact for ANY rate, so the gate can never change the output.
+        rng = MersenneTwister(4242)
+        for L in (64, 127, 1023, 10230, 767250)
+            chips = rand(rng, Int8[-1, 1], L); ct = CL.CodeTable(chips)
+            for cps in (0.95, 0.51, 0.5, 1 / 3, 0.25, 0.126, 0.125, 1 / 12.3, 0.0625,
+                        1 / 17, 0.02, 1 / 64, 1 / 64.7, 1 / 65, 1 / 128, 1 / 1023, 1 / 5000),
+                n in (1, 15, 16, 17, 63, 64, 65, 200, 4096, 12345),
+                phase in (0, L - 1), rem0 in (0, 1, _SD ÷ 3, _SD - 1)
+
+                sn = _step_num(cps)
+                out = Vector{Int8}(undef, n)
+                CL._generate_boundary!(out, ct, sn, _SD, phase, CL._RemT(rem0))
+                @test out == _ref_rem0(chips, sn, rem0, phase, n)
+            end
+        end
+    end
+
     @testset "fractional sub-chip start phase (rem0) — all backends == shifted reference" begin
         # A fixed-point fractional sub-chip offset `rem0 ∈ [0, 2^_B)` seeds the DDA's running
         # remainder so it tracks the SHIFTED stream `((step_num·n + rem0) >> _B + phase)`. Every
-        # PERMUTE backend must match the shifted reference byte-exactly; the high-oversampling
-        # broadcast RUN-FILL gets its documented ≤2-sample boundary tolerance. rem0 = 0 ⇒ the
-        # original integer-phase output.
+        # backend must match the shifted reference byte-exactly — including the
+        # high-oversampling boundary fill, whose exact reciprocal has no tolerance carve-out
+        # (the old run-fill needed ≤2 samples of slack here). rem0 = 0 ⇒ the original
+        # integer-phase output.
         rng = MersenneTwister(123)
         for L in (1023, 257, 64)
             chips = rand(rng, Int8[-1, 1], L); ct = CL.CodeTable(chips)
@@ -228,11 +251,7 @@ const _BACKENDS = (CL.Portable(),
                         for be in _BACKENDS
                             out = Vector{Int8}(undef, n)
                             CL.generate_code!(out, ct, sn, _SD; phase = phase, rem0 = rem0, backend = be)
-                            if CL._use_runfill(sn, _SD, be, n)
-                                @test count(!=(0), out .- ref) <= 2   # run-fill boundary tolerance
-                            else
-                                @test out == ref                      # permute: byte-exact
-                            end
+                            @test out == ref                          # byte-exact in BOTH regimes
                         end
                     end
                 end
@@ -260,47 +279,35 @@ const _BACKENDS = (CL.Portable(),
                         for m in (777, 1, 1024, 64, n - 777 - 1 - 1024 - 64)
                             buf = Vector{Int8}(undef, m); st = CL.fill_continue!(buf, eng, st); append!(got, buf)
                         end
-                        if CL._use_runfill(sn, _SD, be)
-                            @test count(!=(0), got .- ref) <= 4   # accumulated run-fill drift
-                        else
-                            @test got == ref
+                        @test got == ref                      # exact in BOTH regimes
+                        # value-based engine (always permute-based, any rate)
+                        eng = CL.code_engine(ct, sn, _SD, Val(1); phase = phase, rem0 = rem0, backend = be)
+                        W = CL.code_width(eng); col = Int8[]; st = CL.code_state(eng)
+                        for _ in 1:(n ÷ W)
+                            v = CL.code_lookup(eng, st)
+                            for j in 1:W; push!(col, v[j]); end
+                            st = CL.code_advance(eng, st)
                         end
-                        # value-based engine (permute backends only — run-fill has no engine)
-                        if !CL._use_runfill(sn, _SD, be)
-                            eng = CL.code_engine(ct, sn, _SD, Val(1); phase = phase, rem0 = rem0, backend = be)
-                            W = CL.code_width(eng); col = Int8[]; st = CL.code_state(eng)
-                            for _ in 1:(n ÷ W)
-                                v = CL.code_lookup(eng, st)
-                                for j in 1:W; push!(col, v[j]); end
-                                st = CL.code_advance(eng, st)
-                            end
-                            @test col == ref[1:length(col)]
-                        end
+                        @test col == ref[1:length(col)]
                     end
                 end
             end
         end
     end
 
-    @testset "run-fill long-sequence drift + >MAXFILL segmentation" begin
+    @testset "boundary-fill long fills are exact (no drift, no segmentation cap)" begin
+        # The old run-fill's rounded reciprocal drifted ~1–2 samples per ~10⁵ chips and needed
+        # a per-call accumulator cap (`_RUNFILL_MAXFILL`). The boundary fill's magic-reciprocal
+        # boundaries are exact for any dividend a code period can produce, so a multi-million-
+        # sample fill is byte-identical to the floor reference with no segmentation at all.
         chips = rand(MersenneTwister(7), Int8[-1, 1], 1023); ct = CL.CodeTable(chips)
-        # Drift bound: over a long single fill (millions of chips) the approximate DDA may
-        # differ from the exact floor reference, but only by a couple of samples at boundaries.
-        for cps in (1 / 8, 0.0613)            # exact and fractional run-fill rates
-            sn = _step_num(cps); n = 3_000_000
+        for cps in (1 / 8, 0.0613, 1 / 16)    # pow2 (shift path) and fractional (magic path)
+            sn = _step_num(cps); n = 5_000_000
             ref = _ref(chips, sn, 0, n)
             out = Vector{Int8}(undef, n)
-            CL.generate_code!(out, ct, cps; backend = CL.Portable())
-            @test count(!=(0), out .- ref) <= 4      # ≤ a few sub-chip-boundary shifts
+            CL.generate_code!(out, ct, sn, _SD; backend = CL.Portable())
+            @test out == ref
         end
-        # Buffers longer than `_RUNFILL_MAXFILL` exercise the internal segmentation loop (which
-        # caps the per-call accumulator). The segmented output must still track the floor
-        # reference to within the same small drift bound.
-        n = CL._RUNFILL_MAXFILL + 12345; sn = _step_num(1 / 16)
-        @test n > CL._RUNFILL_MAXFILL                       # segmentation actually triggered
-        out = Vector{Int8}(undef, n)
-        CL.generate_code!(out, ct, sn, CL._STEP_DEN; backend = CL.Portable())
-        @test count(!=(0), out .- _ref(chips, sn, 0, n)) <= 4
     end
 
     @testset "modulation (BOC / TMBOC / secondary)" begin
@@ -717,21 +724,24 @@ end
         @test θ2 == 3 && 0 <= r2 < sd
     end
 
-    @testset "high-oversampling generic run-fill (ni>64): generic kernel + segmentation" begin
+    @testset "very high oversampling (m > 62): EXTRAS strided interior stores" begin
+        # Runs longer than the widest splat store (SW = 64) take the `EXTRAS` variant, which
+        # adds SW-strided stores inside each run. Exact, incl. size-1 continuation chunks that
+        # land on/inside run interiors.
         chips = rand(MersenneTwister(21), Int8[-1, 1], 1023); ct = CL.CodeTable(chips)
+        for cps in (1 / 100, 1 / 64.7, 1 / 128, 1 / 5000)
+            sn = _step_num(cps)
+            n = 300_000
+            out = Vector{Int8}(undef, n)
+            CL.generate_code!(out, ct, sn, _SD; backend = CL.Portable())
+            @test out == _ref(chips, sn, 0, n)
+        end
         sn = _step_num(1 / 100)
-        @test CL._runfill_ni(sn) > CL._RUNFILL_MAX_NI     # generic (above the Val ladder)
-        # (a) > _RUNFILL_MAXFILL drives the generic segmentation loop
-        n = CL._RUNFILL_MAXFILL + 12_345
-        out = Vector{Int8}(undef, n)
-        CL.generate_code!(out, ct, sn, _SD; backend = CL.Portable())
-        @test count(!=(0), out .- _ref(chips, sn, 0, n)) <= 4
-        # (b) size-1 continuation lands on chip boundaries → the generic-core boundary return
         eng = CL.make_fill_engine(ct, sn, _SD; backend = CL.Portable()); st = CL.fill_state(eng)
         m = 600; ref = _ref(chips, sn, 0, m); got = Int8[]
         for _ in 1:m
             b = Vector{Int8}(undef, 1); st = CL.fill_continue!(b, eng, st); append!(got, b)
         end
-        @test count(!=(0), got .- ref) <= 4
+        @test got == ref
     end
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -118,7 +118,7 @@ function _gen_code_scalar_oracle(full, sn::Int, sd::Int, rem0::Int, psub::Int, N
     ref
 end
 
-# Returns (oracle::Vector{Int8}, is_runfill::Bool) for `signal`/`prn` at the given rate/phase.
+# Returns the oracle::Vector{Int8} for `signal`/`prn` at the given rate/phase.
 function _gen_code_oracle(signal, prn, fs_u, fc_u, sp, sis, N)
     lut = signal.lut
     P = lut.subchip_factor; Lf = lut.table_length; per = lut.period_subchips
@@ -127,22 +127,15 @@ function _gen_code_oracle(signal, prn, fs_u, fc_u, sp, sis, N)
     fcv = Float64(GNSSSignals._to_hz(fc_u)); fsv = Float64(GNSSSignals._to_hz(fs_u))
     sn, sd = _CL._fixed_point_step((fcv * P) / fsv)
     psub, rem0 = GNSSSignals._subchip_phase_split(sp, sis, fcv, fsv, P, sd)
-    ref = _gen_code_scalar_oracle(full, sn, sd, rem0, psub, N, collect(Int8, sec), per)
-    runfill = _CL._use_runfill(sn, sd, _CL.default_backend(), N)
-    (ref, runfill)
+    _gen_code_scalar_oracle(full, sn, sd, rem0, psub, N, collect(Int8, sec), per)
 end
 
-# Assert the embedded gen_code! equals the oracle (byte-exact in permute regime; ≤2-sample
-# boundary tolerance in the run-fill regime).
+# Assert the embedded gen_code! equals the oracle — byte-exact in BOTH regimes (the exact
+# boundary fill removed the old run-fill's ≤2-sample tolerance).
 function _check_gen_code(signal, prn, fs_u, fc_u, sp, sis, N)
     out = Vector{Int8}(undef, N)
     gen_code!(out, signal, prn, fs_u, fc_u, sp, sis)
-    ref, runfill = _gen_code_oracle(signal, prn, fs_u, fc_u, sp, sis, N)
-    if runfill
-        @test count(!=(0), out .- ref) <= 2
-    else
-        @test out == ref
-    end
+    @test out == _gen_code_oracle(signal, prn, fs_u, fc_u, sp, sis, N)
     out
 end
 


### PR DESCRIPTION
Stacked on #97. Explores the question: *can the permute-vs-run-fill oversampling threshold be removed entirely by one unified algorithm, without compromising speed?*

## Short answer

Not fully — the two regimes are asymptotically different (per-**block** vs per-**chip** work, `N/W` vs `N/m`), so a switch point must exist. What *can* be removed is everything that made the threshold fragile: this PR replaces the approximate `freqfix` run-fill with an **exact boundary-fill kernel**, after which the remaining gate is a pure, N-independent speed choice between two interchangeable exact kernels — it can never change the output.

## The kernel

Chip-major: within a segment anchored at sample `pos` (chip `c0`, fractional phase `r0`), chip `c0+i` starts at, **exactly**,

```
pos + ⌈(i·2^B − r0) / step_num⌉
```

via a `(64+ℓ)`-bit round-up magic reciprocal — by the Granlund–Montgomery bound exact for **every** dividend `< 2^64`, far above the `≤ L·2^B < 2^50` a segment can produce (power-of-two rates are a plain shift). Each chip is one boundary step + one splat store of width `SW = nextpow2(m+2) ∈ {8,16,32,64}` (stores issue left-to-right; the next store overwrites the overhang); runs longer than SW get SW-strided interior stores. No loop-carried DDA, no vector math — one kernel for every backend, any table length.

The boundary step is ISA-selected at compile time (bit-identical either way, same precedent as `vpermb`/`tbl1`): x86 advances the 128-bit product `P_i = (d_i−1)·magic` by the constant `2^B·magic` with a manual add/adc pair; aarch64 prefers four independent `umulh`s per iteration (the CI rounds showed each ISA regressing ~20-30 % on the other's form).

## What the unification removes

| gone | replaced by |
|---|---|
| approximate `freqfix` DDA (~10⁵-chip boundary drift) | exact reciprocal, byte-identical for any fill/chunking |
| `_RUNFILL_MAXFILL` segmentation cap | nothing needed (no accumulator to overflow) |
| `Val{NI}` store-width ladder (4..64) + runtime-generic `ni>64` kernel | 4 static widths + `EXTRAS` flag, all exact |
| `RunFillState(c, acc, pos)` + `rem0` seed conversion | `BoundaryState(c, r)` — the DDA state itself |
| per-backend `_runfill_min_m` **+ N-aware overload** (5 constants) | one N-independent `_use_boundary` gate (10/3/3/2) |
| all `≤2`/`≤4`-sample test tolerances | byte-exact everywhere |

Net −30 lines including stronger tests (forced-kernel sweep over every SW/EXTRAS branch, pow2 + magic paths, wraps, wind-down clamping, scalar tails, L = 64…767250; 5M-sample fills byte-exact; 0-alloc one-shot + engine verified — memory tables all `0 allocs`).

## CI benchmark picture (round 4, `55f1e3e` vs #97 head, benchpkg minimums)

**macos-14 (Apple Silicon, NEON):**
- ✅ GPSL1CA @ 5 MHz **1.27×**, GPSL2CL/CM **1.33/1.40×**, GPSL5/E5a @ 40 MHz **1.20-1.23×**, 8× rows 1.07-1.09×, 17×/24×/4k 1.16-1.23×, 64×/4k 1.4×, 128× **1.67-1.95×**
- ⚠️ 17×-32×/64k: 0.67-0.84

**ubuntu-latest (AVX2):**
- ✅ 8× rows 1.15-1.17×, 128× **1.7-1.86×**; GPSL1CA/L2C/all BOC/2000-sample rows ≈ 1.0
- ⚠️ GPSL5/E5a @ 40 MHz 0.85-0.87 (m ≈ 3.9, right at the gate); 24×-32×/64k 0.68-0.83; 64×/64k 0.84

**Zen 5 AVX-512 (dev machine, min of alternating rounds):** parity below the gate and at m ∈ [32,48], ~1.1-1.3× slower in m ∈ [8,24], 1.6-2.7× faster m ≥ 64 (non-pow2).

The stable residual regression is the **64k-buffer middle band (m ≈ 17-32, ~0.7-0.85×)** — 4k buffers are at parity or better on the same rows, so it is an L2-store-traffic effect rather than per-chip compute; it is the price of exact boundaries vs the old rounded single-add DDA. Everything else is parity or better on all three microarchitectures.

## The remaining gate

`_use_boundary`: boundary fill when `m ≥ 10` (AVX-512) / `3` (AVX2) / `3` (NEON) / `2` (Portable) — measured curve crossings; AVX2/NEON equal the old run-fill values, AVX-512 reflects the faster #97 permute. Near the crossing the kernels are within ~15 % of each other, and since both sides are exact, a wrong gate is a small speed loss, never a correctness or drift change.

## Correctness

- Full suite green on all platforms incl. the AVX-512 SDE-emulation job; codecov patch 99.3 %.
- Forced-kernel sweep vs the Portable oracle (~6.8k configs, all branches) + prototype-stage validation of ~19.5k configs.
- `fill_continue!` continuation byte-identical for any chunking incl. size-1 chunks inside long runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)