### PR TITLE
fix(code_lut): reject step_denominator != 2^30 loudly

### DIFF
--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -304,8 +304,8 @@ const FillEngineAny = Union{FillEngine512,FillEnginePhase,FillEngineBoundary}
 function make_fill_engine(table::CodeTable, step_num::Integer, step_den::Integer;
                           phase::Integer = 0, rem0::Integer = 0,
                           backend::Backend = default_backend(table))
-    (0 < step_den ≤ _STEP_DEN) ||
-        throw(ArgumentError("need 0 < step_denominator ≤ 2^$_B"))
+    (step_den == _STEP_DEN) ||
+        throw(ArgumentError("need step_denominator == 2^$_B (the fixed-point DDA denominator; kernels hardcode it)"))
     (0 < step_num ≤ step_den) ||
         throw(ArgumentError("need 0 < step_numerator ≤ step_denominator (must oversample)"))
     (0 ≤ rem0 < step_den) ||

--- a/src/code_lut/iterate.jl
+++ b/src/code_lut/iterate.jl
@@ -109,8 +109,8 @@ Same oversampling / denominator requirements as `generate_code!`.
 function code_engine(table::CodeTable, step_num::Integer, step_den::Integer, ::Val{K};
                      phase::Integer = 0, rem0::Integer = 0,
                      backend::Backend = default_backend(table)) where {K}
-    (0 < step_den ≤ _STEP_DEN) ||
-        throw(ArgumentError("need 0 < step_denominator ≤ 2^$_B"))
+    (step_den == _STEP_DEN) ||
+        throw(ArgumentError("need step_denominator == 2^$_B (the fixed-point DDA denominator; kernels hardcode it)"))
     (0 < step_num ≤ step_den) ||
         throw(ArgumentError("need 0 < step_numerator ≤ step_denominator (must oversample)"))
     (0 ≤ rem0 < step_den) ||

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -77,15 +77,16 @@ chips_per_sample(code_frequency, sampling_frequency) = code_frequency / sampling
 Fill `out::AbstractVector{Int8}` with `table`'s code resampled so the chip index advances
 by an exact `step_numerator / step_denominator` chips per sample (drift-free integer DDA).
 `phase` is an initial **integer chip offset** (default 0). Requires
-`0 < step_numerator ≤ step_denominator` (oversampling) and a sane denominator
-`0 < step_denominator ≤ 2^_B` (the fixed-point DDA denominator; see `_fixed_point_step`).
+`0 < step_numerator ≤ step_denominator` (oversampling) and exactly
+`step_denominator == 2^_B` (the fixed-point DDA denominator the kernels hardcode; see
+`_fixed_point_step`).
 """
 function generate_code!(out::AbstractVector{<:Integer}, table::CodeTable,
                         step_numerator::Integer, step_denominator::Integer;
                         phase::Integer = 0, rem0::Integer = 0,
                         backend::Backend = default_backend(table))
-    (0 < step_denominator ≤ _STEP_DEN) ||
-        throw(ArgumentError("need 0 < step_denominator ≤ 2^$_B"))
+    (step_denominator == _STEP_DEN) ||
+        throw(ArgumentError("need step_denominator == 2^$_B (the fixed-point DDA denominator; kernels hardcode it)"))
     (0 < step_numerator ≤ step_denominator) ||
         throw(ArgumentError("need 0 < step_numerator ≤ step_denominator (must oversample, chips/sample ≤ 1)"))
     (0 ≤ rem0 < step_denominator) ||

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -96,6 +96,25 @@ const _BACKENDS = (CL.Portable(),
         @test_throws ArgumentError CL.generate_code!(out, ct, _SD + 1, _SD - 1)
     end
 
+    @testset "step_denominator != 2^_B rejected (issue #109)" begin
+        # Every kernel hardcodes the 2^_B denominator (`>> _B`, `& (2^_B-1)`), so any other
+        # denominator must be rejected loudly rather than silently produce garbage. Here
+        # 1/2 chips-per-sample expressed as 1/2 (unsupported) must throw, while the exact
+        # equivalent 2^(_B-1)/2^_B (supported) must produce the correct resampled sequence.
+        chips = rand(MersenneTwister(17), Int8[-1, 1], 1023); ct = CL.CodeTable(chips)
+        n = 4096; sn_half = _SD >> 1   # numerator for exactly 0.5 chips/sample at den = 2^_B
+        for be in _BACKENDS
+            out = Vector{Int8}(undef, n)
+            # Unsupported denominator (2 ≠ 2^_B): all three entry points must throw.
+            @test_throws ArgumentError CL.generate_code!(out, ct, 1, 2; backend = be)
+            @test_throws ArgumentError CL.code_engine(ct, 1, 2, Val(1); backend = be)
+            @test_throws ArgumentError CL.make_fill_engine(ct, 1, 2; backend = be)
+            # Supported denominator (== 2^_B): correct resampled sequence.
+            CL.generate_code!(out, ct, sn_half, _SD; backend = be)
+            @test out == _ref(chips, sn_half, 0, n)
+        end
+    end
+
     @testset "real-frequency interface" begin
         chips = rand(MersenneTwister(42), Int8[-1, 1], 1023); ct = CL.CodeTable(chips)
         n = 20000


### PR DESCRIPTION
## Problem

`generate_code!` documents that "the chip index advances by an exact `step_numerator / step_denominator` chips per sample" and validated `0 < step_denominator ≤ 2^30`. But every kernel **hardcodes** the `2^30` denominator (`>> _B`, `& (2^_B - 1)`), so any `step_denominator != 2^30` passed validation and **silently produced garbage**.

Reproduction (documented as exactly 0.5 chips/sample):

```julia
CodeLUT.generate_code!(out, CodeTable(chips), 1, 2)   # returns all chips[1] (floor(n·1/2^30)=0)
```

CodeLUT is internal and every internal call site passes `_STEP_DEN`, so this is latent today — but the module is a verbatim vendor of GNSSSignalsLUT.jl where the same API would be public.

## Fix

Tighten validation to `step_denominator == 2^_B` with a descriptive error at all three entry points:
- `generate_code!` (`src/code_lut/kernel.jl`)
- `code_engine` (`src/code_lut/iterate.jl`)
- `make_fill_engine` (`src/code_lut/generator.jl`)

Per the issue, this rejects unsupported denominators loudly rather than teaching kernels to honor arbitrary denominators. Docstring updated to match.

## Testing (failing-test-first)

Added a testset in `test/code_lut.jl` (issue #109) that, across all host backends, asserts the three entry points throw `ArgumentError` for `den = 2` and that the supported `2^29 / 2^30` case still resamples correctly.

Verified it **fails on the unfixed code**:
```
generate_code! with den=2 throws? false
code_engine with den=2 throws? false
make_fill_engine with den=2 throws? false
den=2 output all equal to chips[1]? true
```

After the fix, the **full suite passes** (`Pkg.test()`): CodeLUT 9966/9966, Aqua 10/10, no regressions.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)