### PR TITLE
docs: document 2^-30 rate-quantization drift for long constant-rate fills

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -55,6 +55,43 @@ sampling_frequency = 4MHz
 sampled_code = gen_code(4000, gpsl1ca, prn, sampling_frequency, get_code_frequency(gpsl1ca), start_phase)
 ```
 
+### Long Constant-Rate Fills (Rate Quantization)
+
+The resampler's fixed-point DDA quantizes the chips-per-sample rate to a `2^-30` sub-chip
+grid, so within a single constant-rate fill the code phase drifts from the exact requested
+rate by at most `N · 2^-31` sub-chips over `N` samples.
+
+**Closed-loop tracking is unaffected**: integrations are short (the bound is ≈ 1e-4 chips
+for a 200k-sample epoch), and the phase is re-anchored to the exact float `start_phase` on
+every `gen_code!` call and every `code_engine` rebuild (e.g. each Doppler update).
+
+For **open-loop, second-scale constant-rate fills** (simulation, snapshot processing) the
+drift reaches ~0.01–0.02 chips per second at 50 MHz, because the continuing engine never
+re-anchors to the requested float rate. Split such fills into segments of at most ~1e7
+samples (bound ≈ 0.005 sub-chips per segment) and re-anchor each segment with an
+exactly-computed `start_phase`:
+
+```julia
+using GNSSSignals
+using Unitful: Hz, MHz, upreferred
+
+gpsl1ca = GPSL1CA()
+prn = 1
+sampling_frequency = 50MHz
+code_frequency = get_code_frequency(gpsl1ca)
+chips_per_sample = upreferred(code_frequency / sampling_frequency)  # plain Float64
+
+segment_length = 10^7
+buffer = zeros(Int8, segment_length)
+for k in 0:9  # 10 segments = 2 s at 50 MHz
+    # Re-anchor each segment at the exact float phase instead of letting the
+    # quantized DDA rate run across segment boundaries.
+    start_phase = mod(k * segment_length * chips_per_sample, get_code_length(gpsl1ca))
+    gen_code!(buffer, gpsl1ca, prn, sampling_frequency, code_frequency, start_phase)
+    # process buffer...
+end
+```
+
 ## Working with Different GNSS Signals
 
 ### GPS L1 C/A

--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -283,6 +283,15 @@ sub-sample resolution: the phase is split into an integer sub-chip offset plus a
 start_index_shift = 0` gives phase `0` exactly; negative `start_index_shift` is handled
 correctly. Any non-baked secondary (e.g. GPS L5I's NH10) is applied per primary period.
 
+# Rate quantization
+The chips-per-sample rate itself is quantized to the DDA's fixed `2^-30` sub-chip grid, so
+within a fill the phase drifts from the exact requested rate by at most `N · 2^-31`
+sub-chips over `N` samples. This is negligible for closed-loop tracking (≈ 1e-4 chips over
+a 200k-sample epoch, and every call re-anchors to the exact float `start_phase`), but a
+second-scale constant-rate fill (simulation / open-loop snapshot) accrues ~0.01–0.02 chips
+per second at 50 MHz. Split constant-rate fills longer than ~1e7 samples into segments and
+re-anchor each segment via `start_phase`; see the usage docs for an example.
+
 # Requirements
 `sampling_frequency ≥ code_frequency · subchip_factor` (else an error is raised). The embedded
 `SignalLUT` is always present (signals whose modulation the LUT can't bake fail to construct),
@@ -407,7 +416,13 @@ block-to-block continuation (tracking). Non-baked secondaries (e.g. GPS L5I's NH
 supported. For a one-shot fill the [`gen_code!`](@ref)`(out, signal, prn, …)` method is simpler.
 
 Same oversampling requirement and fractional sub-chip phase support as the one-shot
-[`gen_code!`](@ref). `backend` defaults to the host's best SIMD backend; pass a weaker one
+[`gen_code!`](@ref) — including its rate quantization: the engine locks the rate to the
+DDA's `2^-30` sub-chip grid at construction and never re-anchors to the requested float
+rate, so the phase drifts by at most `N · 2^-31` sub-chips over the `N` samples generated
+since the engine's `start_phase` anchor. Closed-loop tracking is unaffected (the engine is
+rebuilt — re-anchoring the phase — on every Doppler update); for open-loop constant-rate
+streaming, rebuild the engine with a freshly computed `start_phase` about every 1e7
+samples. `backend` defaults to the host's best SIMD backend; pass a weaker one
 (e.g. `CodeLUT.AVX2()`/`CodeLUT.Portable()`) to force it — handy for testing the non-default
 paths on a given CPU. Forcing a backend the CPU does not support is invalid.
 """
@@ -467,6 +482,10 @@ this is the hot path), and **return** the state advanced by exactly `length(samp
 Concatenating the outputs of consecutive calls — threading the returned state — equals one big
 generation. Any non-baked secondary (e.g. GPS L5I's NH10) is applied per primary period across
 call boundaries via the state's absolute sample offset. Int8 output only.
+
+Because the engine's rate is fixed on the DDA's `2^-30` sub-chip grid, the phase drift bound
+of `N · 2^-31` sub-chips (see [`code_engine`](@ref)) applies to the *total* `N` samples
+generated since the engine's phase anchor, not per call.
 """
 function gen_code!(sampled_code::AbstractVector{Int8}, eng::CodeFillEngine, st::CodeFillState)
     N = length(sampled_code)
@@ -537,8 +556,9 @@ Build a loop-invariant, value-based code engine over PRN `prn` of `signal` (read
 `signal.lut`) for a `K`-way interleaved fused loop. Pair with `K` states `code_state(eng, k)`
 (`k = 0..K-1`, `W` samples apart) and drive each with [`code_lookup`](@ref) /
 [`code_advance`](@ref); nothing is materialised or heap-allocated. The code-side counterpart
-to SinCosLUT's `carrier_engine`. Same oversampling requirement and fractional sub-chip phase
-support as [`gen_code!`](@ref); a non-baked secondary (e.g. GPS L5I's NH10) or
+to SinCosLUT's `carrier_engine`. Same oversampling requirement, fractional sub-chip phase
+support, and `2^-30` rate quantization (drift ≤ `N · 2^-31` sub-chips over `N` samples) as
+[`gen_code!`](@ref); a non-baked secondary (e.g. GPS L5I's NH10) or
 `sampling_frequency < code_frequency·subchip_factor` raises an error (use the array-filling
 [`gen_code!`](@ref) / continuing [`code_engine`](@ref) without `Val(K)` instead).
 """


### PR DESCRIPTION
## Summary

Documentation-only change addressing #111. The embedded-LUT resampler's fixed-point DDA quantizes the chips-per-sample rate to a `2^-30` sub-chip grid (`src/code_lut/kernel.jl:24-25,56-60`), so a single constant-rate fill drifts from the exact requested rate by at most `N · 2^-31` sub-chips over `N` samples, and the continuing engine never re-anchors to the requested float rate. This is by design and irrelevant to closed-loop tracking, but second-scale open-loop / simulation fills silently accrue ~0.01–0.02 chips/s at 50 MHz.

## Changes

- **Docstrings** (`src/code_lut.jl`): added a "Rate quantization" note to the one-shot `gen_code!`, the continuing `code_engine` and `gen_code!(out, eng, st)`, and the `Val(K)` `code_engine`, stating the `≤ N · 2^-31` sub-chip drift bound and that closed-loop tracking is unaffected.
- **`docs/src/usage.md`**: new "Long Constant-Rate Fills (Rate Quantization)" section explaining the bound, why tracking is unaffected, and a worked example that splits fills beyond ~1e7 samples and re-anchors each segment via `start_phase`.

## Verification

- Full test suite passes (`Testing GNSSSignals tests passed`).
- Docs build cleanly with Documenter (no docstring/cross-reference errors).
- The usage.md example snippet was executed to confirm it runs.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)