### PR TITLE
fix(code_lut): derive CBOC Int8 amplitudes from boc1_power

### DIFF
--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -181,11 +181,12 @@ end # module CodeLUT
 end
 
 # Map a GNSSSignals modulation to a CodeLUT modulation. ±1 for LOC/BOC/TMBOC; CBOC bakes a
-# multi-level Int8 integer approximation of its sqrt-power amplitudes (`cboc_amplitudes`).
+# multi-level Int8 integer approximation of its sqrt-power amplitudes, DERIVED from the CBOC's own
+# `boc1_power` (see `_cboc_int_amplitudes`) unless `cboc_amplitudes` is an explicit override.
 # Errors on cosine BOC and code-factor n ≠ 1. The `cboc_amplitudes` argument is ignored by
 # every modulation except CBOC (the generic two-arg method below forwards to the one-arg form).
 # Used by `build_signal_lut` (eager bake at signal construction).
-_codelut_modulation(m, ::Tuple{Integer,Integer}) = _codelut_modulation(m)
+_codelut_modulation(m, ::Union{Nothing,Tuple{Integer,Integer}}) = _codelut_modulation(m)
 function _codelut_modulation(m::LOC)
     CodeLUT.LOC()
 end
@@ -198,10 +199,38 @@ function _codelut_modulation(m::TMBOC)
         error("the embedded LUT supports only TMBOC with BOC(1,1) base and code-factor n==1")
     CodeLUT.TMBOC(Int(m.boc2.m), collect(Bool, m.pattern))
 end
-function _codelut_modulation(m::CBOC, cboc_amplitudes::Tuple{Integer,Integer})
+# Best integer amplitude pair (a1, a2) for baking a CBOC subcarrier: the continued-fraction
+# convergent of the target amplitude ratio √(boc1_power) : √(1-boc1_power) whose sum stays within
+# the Int8 table budget a1 + a2 ≤ 127. Convergents are the canonical best rational approximations,
+# so the E1 default (boc1_power = 10/11, ratio √10) yields (19, 6) — the historical hardcoded pair.
+function _cboc_int_amplitudes(boc1_power::Real)
+    ratio = sqrt(boc1_power / (1 - boc1_power))          # target a1 : a2
+    h2, h1 = 0, 1                                         # convergent numerators   (h_{-2}, h_{-1})
+    k2, k1 = 1, 0                                         # convergent denominators (k_{-2}, k_{-1})
+    x = float(ratio)
+    best = (1, 1)
+    for _ in 1:64                                         # depth cap; the budget breaks far sooner
+        a = floor(Int, x)
+        h0 = a * h1 + h2
+        k0 = a * k1 + k2
+        h0 + k0 <= typemax(Int8) || break
+        (h0 >= 1 && k0 >= 1) && (best = (h0, k0))
+        h2, h1 = h1, h0
+        k2, k1 = k1, k0
+        frac = x - a
+        frac > 1e-9 || break                             # exhausted the expansion
+        x = 1 / frac
+    end
+    best
+end
+
+function _codelut_modulation(m::CBOC,
+                             cboc_amplitudes::Union{Nothing,Tuple{Integer,Integer}} = nothing)
     (m.boc1.n == 1 && m.boc2.n == 1) ||
         error("the embedded LUT supports only code-factor n==1 CBOC")
-    a1, a2 = cboc_amplitudes
+    # Derive the Int8 amplitude pair from the modulation's own `boc1_power` unless the caller
+    # supplies an explicit `cboc_amplitudes` override.
+    a1, a2 = cboc_amplitudes === nothing ? _cboc_int_amplitudes(m.boc1_power) : cboc_amplitudes
     (a1 > 0 && a2 > 0) ||
         error("cboc_amplitudes must be positive integers; got $cboc_amplitudes")
     Int(a1) + Int(a2) <= typemax(Int8) ||
@@ -217,7 +246,7 @@ function _codelut_modulation(m::BOCcos)
 end
 
 """
-    build_signal_lut(modulation, codes, sec::SecondaryCode; cboc_amplitudes = (19, 6))
+    build_signal_lut(modulation, codes, sec::SecondaryCode; cboc_amplitudes = nothing)
         -> SignalLUT
 
 Bake every PRN's fully-modulated replica into one `SignalLUT` matrix, eagerly at signal
@@ -235,9 +264,13 @@ column otherwise) for runtime application.
 **Errors** for modulations the LUT can't bake (cosine BOC, code-factor n ≠ 1, …) — these are
 unimplemented for the embedded LUT, so the signal fails to construct rather than silently
 omitting its LUT. `_codelut_modulation` raises the specific error.
+
+For a `CBOC` modulation, `cboc_amplitudes = nothing` (the default) derives the Int8 amplitude
+pair from the modulation's own `boc1_power` (see `_cboc_int_amplitudes`); the E1 10/11 split
+yields `(19, 6)`. Pass an explicit `(a1, a2)` tuple to override.
 """
 function build_signal_lut(modulation, codes::AbstractMatrix, sec::SecondaryCode;
-                          cboc_amplitudes::Tuple{Integer,Integer} = (19, 6))
+                          cboc_amplitudes::Union{Nothing,Tuple{Integer,Integer}} = nothing)
     clmod = _codelut_modulation(modulation, cboc_amplitudes)   # throws on unimplemented modulation
     num_prns = size(codes, 2)
     num_prns >= 1 ||

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -718,6 +718,30 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# CBOC Int8 amplitudes are DERIVED from the modulation's own `boc1_power` (issue #112),
+# not hardcoded to E1's (19, 6). The default 10/11 split must still bake to (19, 6); a
+# non-10/11 split must bake amplitudes whose ratio tracks √(boc1_power) : √(1-boc1_power),
+# NOT the fixed (19, 6). `cboc_amplitudes` stays an explicit override.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "CBOC amplitudes derived from boc1_power (#112)" begin
+    # `_codelut_modulation(m::CBOC)` (no override) derives the Int8 pair from `m.boc1_power`.
+    amps(m) = let c = GNSSSignals._codelut_modulation(m)
+        (Int(c.a1), abs(Int(c.a2)))
+    end
+    # (a) the E1 default (10/11) still reproduces the historical (19, 6)
+    @test amps(GNSSSignals.CBOC(GNSSSignals.BOCsin(1, 1), GNSSSignals.BOCsin(6, 1), 10 / 11)) == (19, 6)
+    # (b) a 50/50 split must NOT be (19, 6): its ratio → √0.5 / √0.5 = 1
+    a1, a2 = amps(GNSSSignals.CBOC(GNSSSignals.BOCsin(1, 1), GNSSSignals.BOCsin(6, 1), 0.5))
+    @test (a1, a2) != (19, 6)
+    @test a1 / a2 ≈ sqrt(0.5) / sqrt(1 - 0.5) rtol = 0.05
+    @test a1 + a2 <= typemax(Int8)                      # within the Int8 table budget
+    # explicit `cboc_amplitudes` still overrides the derived pair
+    ovr = GNSSSignals._codelut_modulation(
+        GNSSSignals.CBOC(GNSSSignals.BOCsin(1, 1), GNSSSignals.BOCsin(6, 1), 0.5), (19, 6))
+    @test (Int(ovr.a1), Int(ovr.a2)) == (19, 6)
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # End-to-end fractional-phase parity against the fixed-point scalar oracle (`_ref_rem0`),
 # which IS the definition of correct embedded-LUT output (the LUT was validated byte-for-sign
 # against the original generator in prior PRs). At fractional `start_phase` /


### PR DESCRIPTION
## Summary

The CBOC LUT bake never read the modulation's own power split. `_codelut_modulation(m::CBOC, cboc_amplitudes)` used only the `cboc_amplitudes` pair, whose default `(19, 6)` hardcodes E1's 10/11 split (19/6 ≈ 3.167 vs √10 ≈ 3.162). A `CBOC` with a non-10/11 `boc1_power` baked through `build_signal_lut` silently got a LUT whose amplitude ratio contradicted its declared modulation — wrong correlation weighting, no error.

## Fix

`_codelut_modulation` now **derives** the Int8 amplitude pair from `m.boc1_power` when no override is given: the continued-fraction convergent of the target ratio `√(boc1_power) : √(1-boc1_power)` whose sum stays within the Int8 table budget `a1 + a2 ≤ 127`. Convergents are the canonical best rational approximations, so the E1 10/11 default reproduces the historical `(19, 6)` — now computed, not hardcoded.

- `_cboc_int_amplitudes(boc1_power)` — new helper (continued-fraction convergent under the budget).
- `build_signal_lut(...; cboc_amplitudes = nothing)` — default `nothing` means *derive*; pass an explicit `(a1, a2)` tuple to override.

Sanity of the derivation: `10/11 → (19, 6)`, `1/11 → (6, 19)`, `0.5 → (1, 1)`, `0.75 → (71, 41)` (ratio 1.732 ≈ √3), `0.9 → (3, 1)` — each tracks `√(p/(1-p))`.

## Failing-test-first evidence

Added `@testset "CBOC amplitudes derived from boc1_power (#112)"` in `test/code_lut.jl`: (a) the 10/11 default still bakes to `(19, 6)`; (b) a `0.5` split derives a ratio ≈ 1 (NOT `(19, 6)`); plus the explicit-override path. On the **pre-fix** code test (b) errored — there was no derivation method, and the default path returned `(19, 6)` regardless of `boc1_power` (verified: `0.5`-split baked as `(19, 6)`, ratio 3.17). After the fix all 5 assertions pass.

## Full suite

`julia --project=. -e 'using Pkg; Pkg.test()'` — all pass, including the pre-existing `Galileo E1B CBOC` set (41/41, whose `embedded == cboc_mc(19, 6)` assertion confirms the default derivation reproduces `(19, 6)`) and Aqua (10/10). No regressions.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)