### PR TITLE
fix(code_lut): require Unitful.Frequency at public entry points

### DIFF
--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -121,9 +121,10 @@ end # module CodeLUT
 # all reading the signal's embedded `SignalLUT`. Int8-only output, no scratch Dict, no plan.
 # ─────────────────────────────────────────────────────────────────────────────
 
-# Strip Unitful to a plain Float64 Hz value; pass plain numbers through.
+# Strip a Unitful `Frequency` to a plain Float64 Hz value. The public entry points constrain
+# `sampling_frequency`/`code_frequency` to `Frequency`, so a bare number raises a MethodError
+# there rather than being silently misread as Hz (issue #105); no plain-number method here.
 @inline _to_hz(x::Frequency) = Float64(ustrip(u"Hz", x))
-@inline _to_hz(x) = Float64(x)
 
 # Split a real primary-chip start phase into the sub-chip integer offset `θ_int` and the
 # fixed-point fractional sub-chip residual `rem0 ∈ [0, step_den)` the kernels consume.
@@ -299,8 +300,8 @@ function gen_code!(
     sampled_code::AbstractVector{Int8},
     signal::AbstractGNSSSignal,
     prn::Integer,
-    sampling_frequency,
-    code_frequency = get_code_frequency(signal),
+    sampling_frequency::Frequency,
+    code_frequency::Frequency = get_code_frequency(signal),
     start_phase = 0.0,
     start_index_shift::Integer = 0,
 )
@@ -414,8 +415,8 @@ paths on a given CPU. Forcing a backend the CPU does not support is invalid.
 function code_engine(
     signal::AbstractGNSSSignal,
     prn::Integer,
-    sampling_frequency,
-    code_frequency = get_code_frequency(signal);
+    sampling_frequency::Frequency,
+    code_frequency::Frequency = get_code_frequency(signal);
     start_phase = 0.0,
     start_index_shift::Integer = 0,
     backend::CodeLUT.Backend = CodeLUT.default_backend(),
@@ -542,7 +543,7 @@ support as [`gen_code!`](@ref); a non-baked secondary (e.g. GPS L5I's NH10) or
 `sampling_frequency < code_frequency·subchip_factor` raises an error (use the array-filling
 [`gen_code!`](@ref) / continuing [`code_engine`](@ref) without `Val(K)` instead).
 """
-function code_engine(signal::AbstractGNSSSignal, prn::Integer, sampling_frequency, code_frequency, ::Val{K};
+function code_engine(signal::AbstractGNSSSignal, prn::Integer, sampling_frequency::Frequency, code_frequency::Frequency, ::Val{K};
                      start_phase = 0.0, start_index_shift::Integer = 0) where {K}
     mc = _modulated_code_view(signal.lut, Int(prn))
     fc = _to_hz(code_frequency)
@@ -565,5 +566,5 @@ function code_engine(signal::AbstractGNSSSignal, prn::Integer, sampling_frequenc
                         phase = phase_sub, rem0 = rem0, backend = CodeLUT.default_backend())
 end
 
-code_engine(signal::AbstractGNSSSignal, prn::Integer, sampling_frequency, vk::Val; kwargs...) =
+code_engine(signal::AbstractGNSSSignal, prn::Integer, sampling_frequency::Frequency, vk::Val; kwargs...) =
     code_engine(signal, prn, sampling_frequency, get_code_frequency(signal), vk; kwargs...)

--- a/src/common.jl
+++ b/src/common.jl
@@ -100,8 +100,8 @@ function gen_code(
     num_samples::Integer,
     signal::AbstractGNSSSignal,
     prn::Integer,
-    sampling_frequency,
-    code_frequency = get_code_frequency(signal),
+    sampling_frequency::Frequency,
+    code_frequency::Frequency = get_code_frequency(signal),
     start_phase = 0.0,
     start_index::Integer = 0,
 )

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -411,7 +411,7 @@ end
         P = signal.lut.subchip_factor
         fc = get_code_frequency(signal)
         # A couple of rates, all satisfying fs ≥ fc·P.
-        for fs in (Float64(fc) * P, Float64(fc) * P * 2.5)
+        for fs in (fc * P, fc * P * 2.5)
             eng = code_engine(signal, prn, fs, fc, Val(1))
             W = code_width(eng)
             @test W == Wdef
@@ -458,7 +458,7 @@ end
         signal = GPSL1CA(); prn = 1
         P = signal.lut.subchip_factor
         fc = get_code_frequency(signal)
-        fs = Float64(fc) * P
+        fs = fc * P
         eng = code_engine(signal, prn, fs, fc, Val(1))
         # Drive the value-based loop inside a barrier so the engine type is concrete at
         # the @allocated site — both lookup and the renew-by-value advance must be 0-alloc.
@@ -482,13 +482,13 @@ end
         # Non-baked secondary (GPS L5I NH10) → error at engine construction.
         l5i = GPSL5I()
         fc5 = get_code_frequency(l5i)
-        @test_throws ErrorException code_engine(l5i, 1, Float64(fc5) * l5i.lut.subchip_factor, fc5, Val(1))
+        @test_throws ErrorException code_engine(l5i, 1, fc5 * l5i.lut.subchip_factor, fc5, Val(1))
         # fs < fc·subchip_factor → error.
         l1cd = GPSL1C_D()   # BOC(1,1) → subchip_factor 2
         P = l1cd.lut.subchip_factor
         @test P > 1
         fc1c = get_code_frequency(l1cd)
-        @test_throws ErrorException code_engine(l1cd, 1, Float64(fc1c) * P / 2, fc1c, Val(1))
+        @test_throws ErrorException code_engine(l1cd, 1, fc1c * P / 2, fc1c, Val(1))
     end
 
     # End-to-end public adapter at HIGH oversampling, where the engine uses the broadcast
@@ -501,7 +501,7 @@ end
         for (signal, osr) in ((GPSL1CA(), 40), (GPSL5I(), 32))   # L5I carries the NH10 secondary
             prn = 1
             fc = get_code_frequency(signal)
-            fs = Float64(fc) * osr * signal.lut.subchip_factor
+            fs = fc * osr * signal.lut.subchip_factor
             N = 7000
             # one-shot embedded gen_code! (builds + run-fills from phase 0)
             oneshot = Vector{Int8}(undef, N)
@@ -700,7 +700,7 @@ end
         # sign flip across call boundaries; cross several periods (incl. the -1 chips at NH10
         # indices 4,5,7,9) and require byte-exact agreement with the one-shot gen_code!.
         sig = GPSL5I(); prn = 1
-        fc = get_code_frequency(sig); fs = Float64(fc) * 2
+        fc = get_code_frequency(sig); fs = fc * 2
         N = 230_000                       # > 10 NH10 periods (period = 10230·osr samples)
         oneshot = Vector{Int8}(undef, N); gen_code!(oneshot, sig, prn, fs, fc)
         @test any(==(Int8(-1)), GNSSSignals._signal_lut_secondary(sig.lut, prn))   # negate branch can fire
@@ -744,4 +744,34 @@ end
         end
         @test got == ref
     end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #105: the public entry points (`gen_code!` / `gen_code` / `code_engine`) must
+# require `Unitful.Frequency` for `sampling_frequency` and `code_frequency`. A bare number
+# used to be silently interpreted as Hz — e.g. `code_frequency = 1.023` (meaning MHz) became
+# 1.023 Hz, passing the fs≥fc·P guard trivially and returning a constant all-ones buffer
+# (0 chip transitions instead of 511). A bare frequency must raise `MethodError` again.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "issue #105: public API requires Unitful.Frequency" begin
+    signal = GPSL1CA(); prn = 1
+
+    # A bare Real code_frequency must NOT be silently accepted as Hz.
+    @test_throws MethodError gen_code!(zeros(Int8, 4000), signal, prn, 4MHz, 1.023)
+    @test_throws MethodError gen_code(4000, signal, prn, 4MHz, 1.023)
+    @test_throws MethodError code_engine(signal, prn, 4MHz, 1.023)
+    @test_throws MethodError code_engine(signal, prn, 4MHz, 1.023, Val(1))
+    # A bare Real sampling_frequency is likewise rejected.
+    @test_throws MethodError gen_code!(zeros(Int8, 4000), signal, prn, 4e6, 1.023MHz)
+    @test_throws MethodError code_engine(signal, prn, 4e6, 1.023MHz)
+
+    # The correct Unitful call resolves the intended 1.023 MHz rate: 511 chip transitions
+    # over one 1 ms C/A period (vs 0 for the mis-scaled bare-number bug).
+    buf = zeros(Int8, 4000)
+    gen_code!(buf, signal, prn, 4MHz, 1.023MHz)
+    @test sum(diff(buf) .!= 0) == 511
+    @test gen_code(4000, signal, prn, 4MHz, 1.023MHz) == buf
+
+    # The default-frequency path (code_frequency omitted, derived from the signal) still works.
+    @test sum(diff(gen_code(4000, signal, prn, 4MHz)) .!= 0) == 511
 end


### PR DESCRIPTION
## Problem

Master required `sampling_frequency::Frequency` / `code_frequency::Frequency`, so a bare number raised a `MethodError`. This PR's branch replaced that with unconstrained args funnelled through `_to_hz(x) = Float64(x)`, silently interpreting a bare number as Hz.

```julia
buf = zeros(Int8, 4000)
gen_code!(buf, GPSL1CA(), 1, 4e6u"Hz", 1.023)   # user means 1.023 MHz
```

This ran without error: `code_frequency` became **1.023 Hz**, the only guard (`fs < fc·subchip_factor`) passed trivially, and the buffer came back constant all-ones — **0 chip transitions** instead of the 511 you get with the intended `1.023u"MHz"`. Same for `gen_code` and `code_engine`.

## Fix

Constrain `sampling_frequency` and `code_frequency` to `Unitful.Frequency` on every public entry point — `gen_code!`, `gen_code`, `code_engine`, and `code_engine(…, Val(K))` — matching master. A bare number now raises `MethodError` again.

- The omitted-`code_frequency` path still derives it from the signal's Unitful default (`get_code_frequency`), so that signature is unaffected.
- Dropped the now-unreachable plain-number `_to_hz` fallback; kept the `Frequency` method for unit conversion of the constrained inputs.

## Tests

Added a failing-test-first `issue #105` testset in `test/code_lut.jl` asserting:
- bare-`Real` `code_frequency` / `sampling_frequency` throw `MethodError` for `gen_code!`, `gen_code`, `code_engine`, `code_engine(…, Val(K))`;
- the correct Unitful call yields **511** chip transitions over one 1 ms C/A period;
- the omitted-`code_frequency` default path still works.

Confirmed it fails on the pre-fix code (no exception thrown), passes after. Updated a handful of existing signal-level tests that passed a bare `Float64(fc)*P` for `fs` to keep the frequency Unitful. Full suite (incl. Aqua) is green.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)