### PR TITLE
perf(code_lut): parameterize padded field to avoid copying the LUT column

### DIFF
--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -41,8 +41,11 @@ end
 # interleaved streams (W apart) used for throughput are spawned from the carried stream-0 at
 # the start of each fill. After a fill of M samples the returned state is stream-0 at absolute
 # offset M, so the next call resumes seamlessly.
-struct FillEngine512
-    padded::Vector{Int8}
+# `padded` is parametric (`V<:AbstractVector{Int8}`, like `PreparedCode`) so a zero-copy column
+# view of a `SignalLUT` matrix (a unit-stride `SubArray{Int8}`) is stored as-is; a non-parametric
+# `Vector{Int8}` field would silently `convert`/copy the whole column per build.
+struct FillEngine512{V<:AbstractVector{Int8}}
+    padded::V
     step_num::Int
     step_den::Int
     L::Int
@@ -259,13 +262,21 @@ struct BoundaryState
     r::_RemT                  # fractional chip phase (< 2^_B)
 end
 
-struct FillEngineBoundary{SW,EXTRAS}
-    padded::Vector{Int8}
+# `padded` is parametric (`V<:AbstractVector{Int8}`, like `PreparedCode`) so a zero-copy column
+# view of a `SignalLUT` matrix (a unit-stride `SubArray{Int8}`) is stored as-is; a non-parametric
+# `Vector{Int8}` field would silently `convert`/copy the whole column per build.
+struct FillEngineBoundary{SW,EXTRAS,V<:AbstractVector{Int8}}
+    padded::V
     L::Int
     step_num::Int
     c0::Int             # initial table chip index (for fill_state)
     r0::_RemT           # initial fractional chip phase (for fill_state)
 end
+# Infer `V` from `padded` so the `SW`/`EXTRAS`-only call sites below stay unchanged (Julia only
+# auto-generates the all-params and no-params constructors, not this partially-applied one).
+FillEngineBoundary{SW,EXTRAS}(padded::AbstractVector{Int8}, L::Int, step_num::Int, c0::Int,
+                              r0::_RemT) where {SW,EXTRAS} =
+    FillEngineBoundary{SW,EXTRAS,typeof(padded)}(padded, L, step_num, c0, r0)
 
 function FillEngineBoundary(table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int,
                             rem0::_RemT = _RemT(0))

--- a/src/code_lut/iterate.jl
+++ b/src/code_lut/iterate.jl
@@ -61,8 +61,11 @@ end
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ---- AVX-512 engine + state (incremental rel / scalar base) ----
-struct CodeEngine512
-    padded::Vector{Int8}
+# `padded` is parametric (`V<:AbstractVector{Int8}`, like `PreparedCode` above) so a zero-copy
+# column view of a `SignalLUT` matrix (a unit-stride `SubArray{Int8}`) is stored as-is; a
+# non-parametric `Vector{Int8}` field would silently `convert`/copy the whole column per build.
+struct CodeEngine512{V<:AbstractVector{Int8}}
+    padded::V
     step_num::Int
     step_den::Int
     phase_offset::Int

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -525,6 +525,32 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Issue #107: engine construction must be ZERO-COPY. `_modulated_code_view` passes the padded
+# LUT column as a unit-stride `SubArray{Int8}` view; a concrete `padded::Vector{Int8}` field
+# would implicitly `convert`/copy the whole column on every build (~750 KB for GPSL2CL). The
+# `padded` field of FillEngine512 / FillEngineBoundary / CodeEngine512 must be parametric
+# (`V<:AbstractVector{Int8}`, like PreparedCode) so the view is stored without conversion.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "engine construction is zero-copy (issue #107)" begin
+    sig = GPSL2CL(); prn = 1                    # 767250-chip code → ~750 KB padded column
+    fc = get_code_frequency(sig)
+    coltot = size(sig.lut.padded, 1)            # bytes copied if the field is concrete
+    # Barriers so the built engine type is concrete at the @allocated site.
+    build_fill(s, p, fsx, fcx) = code_engine(s, p, fsx, fcx)
+    build_val(s, p, fsx, fcx)  = code_engine(s, p, fsx, fcx, Val(1))
+    fs_mod  = fc * 4.9                           # ~4.9 samples/chip → FillEngine512 / CodeEngine512
+    fs_high = fc * 12                            # ≥10 samples/chip → FillEngineBoundary
+    # A zero-copy build allocates only the small transient view/engine (a few KB); the concrete
+    # field copies the whole column. Assert well under a full-column copy.
+    bound = 64 * 1024
+    @test bound < coltot                         # the copy really is much larger than the bound
+    build_fill(sig, prn, fs_mod, fc); build_fill(sig, prn, fs_high, fc); build_val(sig, prn, fs_mod, fc)
+    @test (@allocated build_fill(sig, prn, fs_mod,  fc)) < bound   # FillEngine512
+    @test (@allocated build_fill(sig, prn, fs_high, fc)) < bound   # FillEngineBoundary
+    @test (@allocated build_val(sig, prn, fs_mod,   fc)) < bound   # CodeEngine512
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Galileo E1B CBOC support in the LUT path. The subcarrier's two sqrt-power amplitudes are
 # baked as an Int8 *integer approximation* (default (19,6) ≈ (√(10/11), √(1/11)), ratio √10);
 # the permute/run-fill backends carry the resulting multi-level Int8 values verbatim, so the


### PR DESCRIPTION
## Problem — issue #107

`FillEngine512` (`src/code_lut/generator.jl`), `FillEngineBoundary`, and
`CodeEngine512` (`src/code_lut/iterate.jl`) declared a **concrete**
`padded::Vector{Int8}` field, but `code_engine` / `make_fill_engine` build them
from `_modulated_code_view`, which passes `@view lut.padded[1:coltot, prn]` —
a unit-stride `SubArray{Int8}`. Julia's implicit `convert` at struct construction
therefore **allocated and copied the entire padded LUT column on every engine
build** (~750 KB for GPSL2CL per call).

The phase-based engines don't copy because `PreparedCode` (`iterate.jl:20`) is
already parameterized `V<:AbstractVector{Int8}` — its comment documents this
exact pitfall.

## Fix

Parameterize the `padded` field of the three structs as `V<:AbstractVector{Int8}`,
mirroring `PreparedCode`, so the `SubArray` is stored without conversion. A small
convenience constructor infers `V` for the `FillEngineBoundary{SW,EXTRAS}(...)`
call sites (Julia only auto-generates the all-params and no-params constructors,
not the partially-applied one). All dispatch sites use the bare type name and are
unaffected; inference stays concrete.

## Failing-test-first evidence

Added `@testset "engine construction is zero-copy (issue #107)"` measuring
`@allocated` for building each engine from a `GPSL2CL()` view (767313-byte column).

**Before (on current code — test fails):**

| engine | @allocated |
|---|---|
| `FillEngine512` | 767752 B |
| `FillEngineBoundary` | 767688 B |
| `CodeEngine512` | 767432 B |

**After (test passes):**

| engine | @allocated |
|---|---|
| `FillEngine512` | 400 B |
| `FillEngineBoundary` | 336 B |
| `CodeEngine512` | 0 B |

## Verification

- New allocation regression test passes.
- Full suite green, no regressions, incl. Aqua (10/10).
- Generated-code correctness unchanged (existing byte-exact oracle testsets pass).

Closes #107