### PR TITLE
feat(code_lut): bake cosine-phased BOC into the embedded LUT

### DIFF
--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -16,9 +16,11 @@
 # / AVX2 `vpshufb` sliding-window permute over a drift-free integer DDA — or, once the
 # baked table is heavily oversampled (so consecutive samples repeat a chip), an exact
 # boundary fill that splat-stores one chip run per store at the original `gen_code!`'s
-# store-bound speed instead of paying a permute per window. The baked table is Int8: ±1 for BPSK/BOC/TMBOC, or a multi-level
-# integer approximation of the sqrt-power amplitudes for CBOC (Galileo E1B); cosine-BOC is
-# unsupported. Requires sub-chip oversampling (`sampling_frequency ≥ code_frequency · subchip_factor`).
+# store-bound speed instead of paying a permute per window. The baked table is Int8: ±1 for
+# BPSK/BOC (sine or cosine phased)/TMBOC, or a multi-level integer approximation of the sqrt-power
+# amplitudes for CBOC (Galileo E1B). Cosine BOC(m,1) is baked at 4m quarter-sub-chips (the ¼-cycle
+# shift halves the grid); only code-factor n≠1 BOC is unsupported. Requires sub-chip oversampling
+# (`sampling_frequency ≥ code_frequency · subchip_factor`).
 # ─────────────────────────────────────────────────────────────────────────────
 
 # `GNSSSignals.CodeLUT` — internal submodule vendoring the GNSSSignalsLUT.jl SIMD code
@@ -180,10 +182,11 @@ end # module CodeLUT
     (θ_int, rem0)
 end
 
-# Map a GNSSSignals modulation to a CodeLUT modulation. ±1 for LOC/BOC/TMBOC; CBOC bakes a
-# multi-level Int8 integer approximation of its sqrt-power amplitudes, DERIVED from the CBOC's own
-# `boc1_power` (see `_cboc_int_amplitudes`) unless `cboc_amplitudes` is an explicit override.
-# Errors on cosine BOC and code-factor n ≠ 1. The `cboc_amplitudes` argument is ignored by
+# Map a GNSSSignals modulation to a CodeLUT modulation. ±1 for LOC/BOCsin/BOCcos/TMBOC; CBOC
+# bakes a multi-level Int8 integer approximation of its sqrt-power amplitudes, DERIVED from the
+# CBOC's own `boc1_power` (see `_cboc_int_amplitudes`) unless `cboc_amplitudes` is an explicit
+# override. Cosine BOC(m,1) bakes at 4m quarter-sub-chips; only code-factor n ≠ 1 errors. The
+# `cboc_amplitudes` argument is ignored by
 # every modulation except CBOC (the generic two-arg method below forwards to the one-arg form).
 # Used by `build_signal_lut` (eager bake at signal construction).
 _codelut_modulation(m, ::Union{Nothing,Tuple{Integer,Integer}}) = _codelut_modulation(m)
@@ -242,7 +245,8 @@ function _codelut_modulation(m::CBOC,
     CodeLUT.CBOC(Int(m.boc1.m), Int(m.boc2.m), Int8(a1), a2_signed)
 end
 function _codelut_modulation(m::BOCcos)
-    error("the embedded LUT does not support cosine-phased BOC (Int8/±1 only)")
+    m.n == 1 || error("the embedded LUT supports only code-factor n==1 cosine-phased BOC")
+    CodeLUT.BOCcos(Int(m.m))
 end
 
 """
@@ -261,9 +265,10 @@ short secondaries are BAKED into each column, a long overlay (GPS L1C-P, 1800 ch
 RESIDUAL and stored in `SignalLUT.secondary` (per-PRN for a `PerPRNSecondaryCode`, one shared
 column otherwise) for runtime application.
 
-**Errors** for modulations the LUT can't bake (cosine BOC, code-factor n ≠ 1, …) — these are
-unimplemented for the embedded LUT, so the signal fails to construct rather than silently
-omitting its LUT. `_codelut_modulation` raises the specific error.
+**Errors** for modulations the LUT can't bake (code-factor n ≠ 1, …) — these are unimplemented
+for the embedded LUT, so the signal fails to construct rather than silently omitting its LUT.
+Cosine-phased BOC(m,1) *is* supported (baked at 4m quarter-sub-chips). `_codelut_modulation`
+raises the specific error for the remaining unimplemented cases.
 
 For a `CBOC` modulation, `cboc_amplitudes = nothing` (the default) derives the Int8 amplitude
 pair from the modulation's own `boc1_power` (see `_cboc_int_amplitudes`); the E1 10/11 split

--- a/src/code_lut/modulation.jl
+++ b/src/code_lut/modulation.jl
@@ -9,6 +9,8 @@
 #
 #   LOC (BPSK):   P = 1,  sub-chip sign = +1
 #   BOC(m,1) sin: P = 2m, sub-chip k sign = iseven(k) ? +1 : -1
+#   BOC(m,1) cos: P = 4m, sub-chip k sign = iseven((k+m)÷2) ? +1 : -1 (sine shifted a ¼ cycle;
+#                 the shift straddles the sine grid, so quarter-sub-chips align every boundary)
 #   TMBOC(m2):    P = 2·m2, BOC(1,1) at most chip positions, BOC(m2,1) at `pattern`
 #                 positions (the high-rate component sets the resolution)
 #   CBOC(m1,m2):  P = 2·lcm(m1,m2), sub-chip value = a1·BOC(m1,1) ± a2·BOC(m2,1) — a multi-
@@ -33,6 +35,10 @@ struct BOC <: Modulation                        # sine-phased BOC(m, 1)
     m::Int
 end
 BOC() = BOC(1)
+struct BOCcos <: Modulation                      # cosine-phased BOC(m, 1)
+    m::Int
+end
+BOCcos() = BOCcos(1)
 struct TMBOC <: Modulation                      # BOC(1,1) + BOC(m2,1) at `pattern` positions
     m2::Int
     pattern::Vector{Bool}                       # pattern[(pos mod end)+1] == true → use BOC(m2,1)
@@ -49,6 +55,7 @@ end
 
 subchip_factor(::LOC)   = 1
 subchip_factor(b::BOC)  = 2 * b.m
+subchip_factor(b::BOCcos) = 4 * b.m            # quarter-sub-chips: the ¼-cycle cosine shift halves the grid
 subchip_factor(t::TMBOC) = 2 * t.m2
 subchip_factor(c::CBOC) = 2 * lcm(c.m1, c.m2)
 
@@ -56,6 +63,11 @@ subchip_factor(c::CBOC) = 2 * lcm(c.m1, c.m2)
 # ±1 for BPSK/BOC/TMBOC; a multi-level integer for CBOC (see below).
 @inline _sc_sign(::LOC, k, pos, P)  = Int8(1)
 @inline _sc_sign(b::BOC, k, pos, P) = iseven(k) ? Int8(1) : Int8(-1)
+# Cosine BOC(m,1) at P = 4m: the sub-carrier is the sine BOC shifted by a quarter cycle
+# (`get_subcarrier_code(BOCcos, φ) == get_subcarrier_code(BOCsin, φ+¼)`). At the sub-chip
+# midpoint φ = pos + (k+½)/(4m), `floor((φ+¼)·2m)` reduces to `pos·2m + (k+m)÷2`; `pos·2m` is
+# even, so the sign is position-independent: `iseven((k+m)÷2)`. Matches the float spec exactly.
+@inline _sc_sign(b::BOCcos, k, pos, P) = iseven((k + b.m) ÷ 2) ? Int8(1) : Int8(-1)
 @inline function _sc_sign(t::TMBOC, k, pos, P)
     if @inbounds t.pattern[mod(pos, length(t.pattern)) + 1]   # BOC(m2,1): flips every sub-chip
         iseven(k) ? Int8(1) : Int8(-1)
@@ -97,8 +109,8 @@ Base.length(mc::ModulatedCode) = length(mc.table)
     code_replica(primary_chips, modulation; secondary=Int8[1], max_bake=typemax(Int16))
 
 Build a [`ModulatedCode`](@ref) from a primary ±1 `primary_chips` vector and a
-`modulation` (`LOC()`, `BOC(m)`, `TMBOC(m2, pattern)`, or `CBOC(m1, m2, a1, a2)`). The
-table is ±1 for the first three; for `CBOC` it holds the multi-level integer composite
+`modulation` (`LOC()`, `BOC(m)`, `BOCcos(m)`, `TMBOC(m2, pattern)`, or `CBOC(m1, m2, a1, a2)`).
+The table is ±1 for all but `CBOC`; for `CBOC` it holds the multi-level integer composite
 `a1·BOC(m1,1) ± a2·BOC(m2,1)` (still Int8, so all backends resample it unchanged).
 `secondary` is a ±1 overlay
 that multiplies whole primary periods; it is baked into the table when

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -735,6 +735,7 @@ end
         for m in (1, 2, 6)
             @test GNSSSignals._codelut_modulation(BOCcos(m, 1)) == CL.BOCcos(m)
         end
+        @test CL.BOCcos() == CL.BOCcos(1)                # zero-arg defaults to m == 1
         @test_throws ErrorException GNSSSignals._codelut_modulation(BOCcos(2, 2))
     end
 

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -718,6 +718,70 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Cosine-phased BOC support in the LUT path. A cosine BOC(m,1) is the sine BOC(m,1) sub-carrier
+# shifted by a quarter cycle (`GNSSSignals.get_subcarrier_code(BOCcos, φ) == get_subcarrier_code(BOCsin, φ+¼)`),
+# so its constant segments straddle the sine sub-chip grid. Baking it at `P = 4m` quarter-sub-chips
+# per chip aligns every segment boundary to the grid, and each sub-chip carries the fixed ±1
+# cosine sign. The float reference is the package's own `GNSSSignals.get_subcarrier_code(BOCcos(m,1), φ)` — the
+# `get_code` BOC path (primary × subcarrier, n == 1, no secondary) sampled at the sub-chip rate.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "cosine-phased BOC (LUT quarter-sub-chip bake)" begin
+    rng = MersenneTwister(7)
+    Lp = 64
+    primary = rand(rng, Int8[-1, 1], Lp)
+    codes = reshape(Int16.(primary), Lp, 1)             # single-PRN code matrix for build_signal_lut
+
+    @testset "_codelut_modulation maps BOCcos(m,1); n != 1 errors" begin
+        for m in (1, 2, 6)
+            @test GNSSSignals._codelut_modulation(BOCcos(m, 1)) == CL.BOCcos(m)
+        end
+        @test_throws ErrorException GNSSSignals._codelut_modulation(BOCcos(2, 2))
+    end
+
+    @testset "baked table = P = 4m quarter-sub-chips, signs match float get_subcarrier_code" for m in (1, 2, 3, 6)
+        P = 4 * m
+        mc = CL.code_replica(primary, CL.BOCcos(m); max_bake = typemax(Int16))
+        @test mc.subchip_factor == P
+        @test length(mc.table) == Lp * P
+        # Float truth: sub-chip k of primary chip c carries primary[c] × cosine subcarrier at the
+        # sub-chip midpoint phase (c + (k+0.5)/P); this is exactly the get_code BOC value there.
+        ref = Int8[Int8(primary[c + 1] *
+                        GNSSSignals.get_subcarrier_code(BOCcos(m, 1), c + (k + 0.5) / P))
+                   for c in 0:Lp-1 for k in 0:P-1]
+        @test mc.table.chips == ref
+    end
+
+    @testset "build_signal_lut bakes BOCcos (no longer throws); column == code_replica" for m in (1, 2, 6)
+        P = 4 * m
+        lut = GNSSSignals.build_signal_lut(BOCcos(m, 1), codes, NoSecondaryCode())
+        @test lut.subchip_factor == P
+        @test lut.table_length == Lp * P
+        mc = CL.code_replica(primary, CL.BOCcos(m); max_bake = typemax(Int16))
+        @test lut.padded[1:lut.table_length, 1] == mc.table.chips
+    end
+
+    @testset "resampled output matches float get_code (BOC path) sampled at fc·P" for m in (1, 2, 3)
+        P = 4 * m
+        mc = CL.code_replica(primary, CL.BOCcos(m); max_bake = typemax(Int16))
+        N = Lp * P                                       # one full code period at fs = fc·P
+        fc = 1.0; fs = fc * P
+        # At fs = fc·P sample n (0-based) is exactly sub-chip n; evaluate the get_code BOC value
+        # (n == 1, no secondary: primary[floor φ] × cosine subcarrier φ) at that sub-chip's
+        # MIDPOINT φ = (n + 0.5)/P. The subcarrier is constant across the sub-chip, so the midpoint
+        # is the get_code value the whole sample represents — and it avoids evaluating exactly on a
+        # sub-chip boundary, where `floor((φ+¼)·2m)` is ill-defined in Float64 (e.g. 7.0 → 6.999…).
+        mid = ((0:N-1) .+ 0.5) .* (fc / fs)
+        ref = Int8[Int8(primary[mod(floor(Int, φ), Lp) + 1] *
+                        GNSSSignals.get_subcarrier_code(BOCcos(m, 1), φ)) for φ in mid]
+        for be in _BACKENDS
+            out = Vector{Int8}(undef, N)
+            CL.generate_code!(out, mc; code_frequency = fc, sampling_frequency = fs, backend = be)
+            @test out == ref
+        end
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # CBOC Int8 amplitudes are DERIVED from the modulation's own `boc1_power` (issue #112),
 # not hardcoded to E1's (19, 6). The default 10/11 split must still bake to (19, 6); a
 # non-10/11 split must bake amplitudes whose ratio tracks √(boc1_power) : √(1-boc1_power),


### PR DESCRIPTION
## Summary

Fixes #106. Cosine-phased BOC (and BOCsin with n≠1) was dropped from the sampled-code path when the LUT resampler replaced master's `multiply_with_subcarrier!`, but `docs/src/index.md` still listed **BOCcos** as a supported modulation. Any signal whose `get_modulation` returns `BOCcos` could no longer build a `SignalLUT` — `_codelut_modulation(::BOCcos)` threw `"the embedded LUT does not support cosine-phased BOC"`.

Per the issue decision, this **bakes cosine-phased BOC(m,1) into the embedded LUT**.

## How

A cosine BOC(m,1) is the sine BOC(m,1) sub-carrier shifted by a quarter cycle — this repo's float truth is literally `get_subcarrier_code(BOCcos, φ) == get_subcarrier_code(BOCsin, φ + ¼)`. That quarter-cycle shift straddles the sine `2m`-sub-chip grid, so I bake it at **`P = 4m` quarter-sub-chips per chip**: every sub-carrier segment boundary then lands exactly on the grid, and each sub-chip carries the fixed cosine sign

```
_sc_sign(BOCcos(m), k, pos, P) = iseven((k + m) ÷ 2) ? +1 : -1
```

derived analytically from `floor((φ+¼)·2m)` at the sub-chip midpoint `φ = pos + (k+½)/(4m)` (position-independent because `pos·2m` is even). Verified to match the package's own float `get_subcarrier_code(BOCcos(m,1), ·)` exactly for m = 1, 2, 3, 6.

- Added `CodeLUT.BOCcos` descriptor + `subchip_factor = 4m` + `_sc_sign` (`src/code_lut/modulation.jl`).
- `_codelut_modulation(::BOCcos)` now maps to `CodeLUT.BOCcos(m)` and the error path is removed (`src/code_lut.jl`).
- Updated the stale "cosine-BOC is unsupported" comments/docstrings.
- `docs/src/index.md`'s "BOCcos — Cosine-phased Binary Offset Carrier" entry is now truthful; no wording change needed.

## BOCsin / BOCcos with n ≠ 1 — still errors (intentional)

n ≠ 1 remains unsupported and errors with a clear message. The primary code advances at `n` chips per unit phase (`get_floored_phase = floor(phase·n)`) while the sub-carrier flips `2m` times per unit phase, giving a **generally non-integer `2m/n` (cosine `4m/n`) sub-chips-per-primary-chip ratio** that the integer-`P` LUT expansion cannot represent without a redesign of the bake machinery. No built-in signal uses n ≠ 1, so this is infeasible-within-the-same-machinery rather than a real gap — exactly the fallback the issue permits. BOCcos is fully supported.

## Failing-test-first

Added the `"cosine-phased BOC (LUT quarter-sub-chip bake)"` testset in `test/code_lut.jl` **before** implementing. On the pre-fix code it errored 13× with `"the embedded LUT does not support cosine-phased BOC"` / undefined `CL.BOCcos`. After the fix all **34** assertions pass. The testset covers:
- `_codelut_modulation(BOCcos(m,1)) == CL.BOCcos(m)`; `BOCcos(2,2)` errors.
- `code_replica` bakes `P = 4m` quarter-sub-chips whose signs equal the float `get_subcarrier_code` at each sub-chip.
- `build_signal_lut(BOCcos(m,1), codes, NoSecondaryCode())` no longer throws; its baked column equals `code_replica`.
- Resampled output at `fs = fc·P` equals the float `get_code` BOC reference (evaluated at sub-chip midpoints to avoid Float64 knife-edge boundary rounding) across **all backends**.

## Test suite

Full `Pkg.test()` passes with no regressions, including Aqua and the full `CodeLUT` sweep (9954 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)