### PR TITLE
fix(code_lut): route strided Int8 targets through an indexed fallback

### DIFF
--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -288,7 +288,14 @@ end
 function fill_continue!(out::AbstractVector{<:Integer}, eng::FillEngineBoundary{SW,EXTRAS},
                         st::BoundaryState) where {SW,EXTRAS}
     SN = Int64(eng.step_num)
-    _boundary_fill!(out, eng.padded, eng.L, SN, st.c, Int64(st.r), Val(SW), Val(EXTRAS))
+    if _is_dense_target(out)
+        _boundary_fill!(out, eng.padded, eng.L, SN, st.c, Int64(st.r), Val(SW), Val(EXTRAS))
+    else
+        # Strided / non-contiguous target: `_boundary_fill!`'s pointer stores would corrupt
+        # neighbouring memory (issue #103), so fill via the plain indexed per-sample DDA walk
+        # (`_boundary_scalar_tail!` — byte-identical to the boundary kernel, just slower).
+        _boundary_scalar_tail!(out, eng.padded, eng.L, SN, st.c, Int64(st.r), 0)
+    end
     # advance the state by exactly length(out) samples, arithmetically (exact)
     tot = Int64(st.r) + Int64(length(out)) * SN
     BoundaryState(Int(mod(Int64(st.c) + (tot >> _B), eng.L)), _RemT(tot & Int64(_STEP_DEN - 1)))

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -68,6 +68,15 @@ Pass the result to [`generate_code!`](@ref) / [`generate_code`](@ref). Must be �
 """
 chips_per_sample(code_frequency, sampling_frequency) = code_frequency / sampling_frequency
 
+# Pointer/`VecRange`-safe output targets for the fast kernels (boundary fill + windowed
+# permute), which write through `pointer(out)` / SIMD `VecRange` stores assuming UNIT STRIDE.
+# A plain `Vector` and a unit-stride contiguous `SubArray` satisfy that; strided views (e.g. a
+# matrix row) do NOT — routing them to those kernels clobbers neighbouring memory (issue #103),
+# so callers send them through the plain indexed Portable fallback instead.
+@inline _is_dense_target(::Vector) = true
+@inline _is_dense_target(::Base.FastContiguousSubArray) = true
+@inline _is_dense_target(::AbstractVector) = false
+
 # ===== generate_code! =====
 """
     generate_code!(out, table, step_numerator, step_denominator; phase=0, backend=…)
@@ -91,10 +100,17 @@ function generate_code!(out::AbstractVector{<:Integer}, table::CodeTable,
         throw(ArgumentError("need 0 < step_numerator ≤ step_denominator (must oversample, chips/sample ≤ 1)"))
     (0 ≤ rem0 < step_denominator) ||
         throw(ArgumentError("need 0 ≤ rem0 < step_denominator (fractional sub-chip offset)"))
-    if out isa AbstractVector{Int8} && _use_boundary(Int(step_numerator), Int(step_denominator), backend)
-        _generate_boundary!(out, table, Int(step_numerator), Int(step_denominator), Int(phase), _RemT(rem0))
+    sn = Int(step_numerator); sd = Int(step_denominator); ph = Int(phase); r0 = _RemT(rem0)
+    if !_is_dense_target(out)
+        # Strided / non-contiguous target (e.g. a matrix row view): the boundary and windowed-
+        # permute kernels write through `pointer(out)` / `VecRange` stores assuming unit stride,
+        # which would corrupt neighbouring memory (issue #103). Walk it with the plain indexed
+        # scalar generator instead — correct for any `AbstractVector`, just slower.
+        _generate!(out, table, sn, sd, ph, Portable(), r0)
+    elseif out isa AbstractVector{Int8} && _use_boundary(sn, sd, backend)
+        _generate_boundary!(out, table, sn, sd, ph, r0)
     else
-        _generate!(out, table, Int(step_numerator), Int(step_denominator), Int(phase), backend, _RemT(rem0))
+        _generate!(out, table, sn, sd, ph, backend, r0)
     end
     out
 end

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -1000,3 +1000,46 @@ end
     # The default-frequency path (code_frequency omitted, derived from the signal) still works.
     @test sum(diff(gen_code(4000, signal, prn, 4MHz)) .!= 0) == 511
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Strided (non-contiguous) Int8 output targets. The pointer/`VecRange`-based boundary and
+# windowed-permute kernels assume unit stride; a strided view (e.g. a row of a matrix) must
+# be routed through the plain indexed fallback instead of corrupting neighbouring memory.
+# Regression test for issue #103 (boundary-fill silently clobbered the untouched matrix row).
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "strided Int8 view targets (issue #103)" begin
+    # 20.46 MHz over GPS L1CA's 1.023 MHz gives m ≈ 20 samples/chip → boundary-fill path.
+    fs = 20.46MHz
+    N = 4000
+    signal = GPSL1CA()
+    ref = gen_code(N, signal, 1, fs)
+
+    @testset "one-shot gen_code! into a matrix row" begin
+        A = zeros(Int8, 2, N)
+        v = view(A, 1, :)                       # strided (stride 2), NOT contiguous
+        gen_code!(v, signal, 1, fs)
+        @test collect(v) == ref                 # the view itself must match the oracle
+        @test all(==(0), @view A[2, :])         # the untouched row must stay all-zero
+    end
+
+    @testset "continuing code_engine fill into a matrix row" begin
+        A = zeros(Int8, 2, N)
+        v = view(A, 1, :)
+        eng = code_engine(signal, 1, fs)
+        st = code_state(eng)
+        gen_code!(v, eng, st)
+        @test collect(v) == ref
+        @test all(==(0), @view A[2, :])
+
+        # chunked continuation into successive strided sub-views must also stay exact
+        B = zeros(Int8, 2, N)
+        st2 = code_state(eng)
+        pos = 0
+        for chunk in (1000, 1500, 1500)
+            st2 = gen_code!(view(B, 1, (pos + 1):(pos + chunk)), eng, st2)
+            pos += chunk
+        end
+        @test collect(@view B[1, :]) == ref
+        @test all(==(0), @view B[2, :])
+    end
+end

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -1042,4 +1042,15 @@ end
         @test collect(@view B[1, :]) == ref
         @test all(==(0), @view B[2, :])
     end
+
+    @testset "contiguous column view stays on the fast path" begin
+        # A unit-stride column view IS a `FastContiguousSubArray`, so it is a dense target and
+        # must still take the pointer/`VecRange` fast kernels — and produce the exact result.
+        A = zeros(Int8, N, 2)
+        col = view(A, :, 1)
+        @test col isa Base.FastContiguousSubArray
+        gen_code!(col, signal, 1, fs)
+        @test collect(col) == ref
+        @test all(==(0), @view A[:, 2])
+    end
 end


### PR DESCRIPTION
## Problem (issue #103)

The boundary-fill kernel (dispatch at `src/code_lut/kernel.jl`, stores in `_boundary_fill!`) accepted any `AbstractVector{Int8}` — the docstring even says "or any `AbstractVector{Int8}`" — but writes through `pointer(out)` / `vstore` / `unsafe_store!` assuming **unit stride**. Passing a strided view silently corrupted neighbouring memory:

```julia
A = zeros(Int8, 2, 4000)
gen_code!(view(A, 1, :), GPSL1CA(), 1, 20.46e6u"Hz")  # m ≈ 20 → boundary kernel
```

The kernel stored contiguous bytes starting at `A[1,1]`, clobbering ~2000 entries of the untouched row `A[2,:]`, and the view's own contents didn't match `gen_code(4000, …)`. The continuing `fill_continue!` for `FillEngineBoundary` had the identical hazard. (The permute path at least raised a `MethodError`; the boundary path corrupted silently.)

## Fix

- Add `_is_dense_target(out)` — true for `Vector` and unit-stride `FastContiguousSubArray`, false otherwise.
- One-shot `generate_code!`: strided/non-contiguous targets now route through the plain indexed scalar generator (`_generate!(…, Portable(), …)`); dense targets keep the unchanged fast boundary / windowed-permute path.
- Continuing `fill_continue!(::FillEngineBoundary)`: strided targets fill via `_boundary_scalar_tail!` (the per-sample DDA walk, byte-identical to the boundary kernel), dense targets keep `_boundary_fill!`.

Output is byte-identical to the fast path for dense targets; strided targets are correct (just slower).

## Failing-test-first evidence

New regression test `@testset "strided Int8 view targets (issue #103)"` covers the one-shot and continuing (incl. chunked) paths into a strided matrix row.

**Before the fix** (current code), all 6 assertions fail — the view doesn't match the oracle and the untouched row has 2000 clobbered entries:

```
Test Summary:                                   | Fail  Total
strided Int8 view targets (issue #103)          |    6      6
  one-shot gen_code! into a matrix row          |    2      2
  continuing code_engine fill into a matrix row |    4      4
```

**After the fix** — all pass:

```
Test Summary:                          | Pass  Total
strided Int8 view targets (issue #103) |    6      6
```

## Full suite

`julia --project=. -e 'using Pkg; Pkg.test()'` passes end-to-end, including Aqua (10/10) — no regressions.

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)