### PR TITLE
refactor(code_lut): unify DDA carry-advance and secondary-code period-walk

### DIFF
--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -481,32 +481,10 @@ end
 @inline function _apply_secondary_continue!(out::AbstractVector{<:Integer}, eng::CodeFillEngine, n0::Int)
     sec = eng.secondary
     length(sec) <= 1 && return out
-    Ls = length(sec); per = eng.period_subchips
-    sn = eng.step_num; sd = eng.step_den
-    N = length(out); ps = eng.phase_sub; r0 = eng.rem0
-    # Absolute sample n (0-based) maps to sub-chip floor((n·sn + rem0)/sd) + ps; period p spans
-    # sub-chips [p·per, (p+1)·per). First sample of period p: smallest n with sub-chip ≥ p·per,
-    # i.e. n ≥ cld(T·sd − rem0, sn) (T·sd > rem0 whenever T ≥ 1, since rem0 < sd). Omitting rem0
-    # would misplace the sign flip by a sample at a period edge for a fractional start phase.
-    # The first emitted sample is absolute n0, so window index = n - n0.
-    sub0 = (n0 * sn + r0) ÷ sd + ps
-    p = fld(sub0, per)              # period index of the first emitted sample
-    @inbounds while true
-        T0 = p * per - ps
-        n_start = T0 <= 0 ? 0 : cld(T0 * sd - r0, sn) # absolute first sample of period p
-        n_start - n0 >= N && break
-        T1 = (p + 1) * per - ps
-        n_end = min(T1 <= 0 ? 0 : cld(T1 * sd - r0, sn), n0 + N)  # absolute end (exclusive)
-        if sec[mod(p, Ls) + 1] == -1
-            lo = max(n_start, n0) - n0 + 1            # 1-based into out
-            hi = n_end - n0                            # 1-based inclusive
-            @simd for n in lo:hi
-                out[n] = -out[n]
-            end
-        end
-        p += 1
-    end
-    out
+    # Same period-walk as the one-shot fill, generalised by the absolute sample offset `n0`
+    # (see `CodeLUT._apply_secondary!`); n0 = 0 reproduces the one-shot version exactly.
+    CodeLUT._apply_secondary!(out, sec, eng.period_subchips, eng.step_num, eng.step_den,
+                              eng.phase_sub, eng.rem0, n0)
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -144,15 +144,10 @@ end
 # final sub-window tail, so the scalar cost is bounded (< 64 iterations) and off the hot path.
 @inline function _advance_scalar_512(rel::Vec{64,Int8}, rem::Vec{64,_RemT}, base::Int,
                                      m::Int, step_num::Int, step_den::Int, modulus::_RemT, L::Int)
-    frac1 = _RemT(step_num % step_den); whole1 = step_num ÷ step_den
+    frac1 = _RemT(step_num % step_den); whole1 = step_num ÷ step_den   # whole1 ∈ {0,1} < L
     r = rem; rl = rel; b = base
     @inbounds for _ in 1:m
-        r2 = r + frac1
-        carry = r2 >= modulus
-        r = vifelse(carry, r2 - modulus, r2)
-        h = Int(carry[1])
-        rl = rl + vifelse(carry, one(Vec{64,Int8}), zero(Vec{64,Int8})) - Int8(h)
-        b = _wrapL(b + whole1 + h, L)   # whole1 ∈ {0,1} < L ⇒ sum < 2L
+        rl, r, b = _advance_window_512(rl, r, b, frac1, whole1, modulus, L)
     end
     (rl, r, b)
 end
@@ -198,15 +193,11 @@ end
     CodeStatePhase{W,T}(phase, rem)
 end
 
-@inline function _advance_window_phase(phase::Vec{W,T}, rem::Vec{W,_RemT}, whole_W::T,
-                                       frac_W::_RemT, modulus::_RemT, Lc::T) where {W,T}
-    rem2 = rem + frac_W
-    carry = rem2 >= modulus
-    rem2 = vifelse(carry, rem2 - modulus, rem2)
-    phase2 = vifelse(carry, phase + whole_W + one(T), phase + whole_W)
-    phase2 = vifelse(phase2 >= Lc, phase2 - Lc, phase2)
-    (phase2, rem2)
-end
+# One W-window phase advance = the canonical `_advance_phase` (iterate.jl) with the per-window
+# deltas (whole_W / frac_W); kept as a named wrapper for the fill loop's call site.
+@inline _advance_window_phase(phase::Vec{W,T}, rem::Vec{W,_RemT}, whole_W::T,
+                              frac_W::_RemT, modulus::_RemT, Lc::T) where {W,T} =
+    _advance_phase(phase, rem, frac_W, whole_W, modulus, Lc)
 
 function fill_continue!(out::AbstractVector{<:Integer}, eng::FillEnginePhase{W,T}, st::CodeStatePhase{W,T}) where {W,T}
     p = eng.prepared; whole_W = eng.whole_W; frac_W = eng.frac_W; modulus = eng.modulus; Lc = eng.code_length
@@ -235,11 +226,7 @@ end
     frac1 = _RemT(step_num % step_den); whole1 = T(step_num ÷ step_den)
     ph = phase; r = rem
     @inbounds for _ in 1:m
-        r2 = r + frac1
-        carry = r2 >= modulus
-        r = vifelse(carry, r2 - modulus, r2)
-        ph = vifelse(carry, ph + whole1 + one(T), ph + whole1)
-        ph = vifelse(ph >= Lc, ph - Lc, ph)
+        ph, r = _advance_phase(ph, r, frac1, whole1, modulus, Lc)
     end
     (ph, r)
 end

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -152,15 +152,9 @@ end
 # One DDA micro-advance (frac = rem0, whole = 0) for the phase-form state. Adds the fractional
 # sub-chip start offset to every lane's running remainder, carrying ≤1 chip. Used to seed a
 # fractional start phase at setup; the steady-state advance is unchanged.
-@inline function _seed_micro_phase(phase::Vec{W,T}, rem::Vec{W,_RemT}, rem0::_RemT,
-                                   modulus::_RemT, Lc::T) where {W,T}
-    rem2 = rem + rem0
-    carry = rem2 >= modulus
-    rem3 = vifelse(carry, rem2 - modulus, rem2)
-    phase2 = vifelse(carry, phase + one(T), phase)
-    phase2 = vifelse(phase2 >= Lc, phase2 - Lc, phase2)
-    (phase2, rem3)
-end
+@inline _seed_micro_phase(phase::Vec{W,T}, rem::Vec{W,_RemT}, rem0::_RemT,
+                          modulus::_RemT, Lc::T) where {W,T} =
+    _advance_phase(phase, rem, rem0, zero(T), modulus, Lc)   # whole = 0: pure fractional seed
 
 # One windowed lookup: phase (chip indices mod L for W consecutive samples) -> W chips.
 # base = lane-0 chip; relative index of every lane is in 0..W-1 (≤ 63) because we

--- a/src/code_lut/modulation.jl
+++ b/src/code_lut/modulation.jl
@@ -162,25 +162,36 @@ end
 # match the baked-table lookup, or the sign flip lands on the wrong sample at a period edge).
 function _apply_secondary!(out, mc::ModulatedCode, code_frequency, sampling_frequency, phase_sub,
                            rem0::_RemT = _RemT(0))
-    Ls = length(mc.secondary); per = mc.period_subchips
     sn, sd = _fixed_point_step(code_frequency * mc.subchip_factor / sampling_frequency)
-    phase_sub = Int(phase_sub); r0 = Int(rem0)
-    N = length(out)
-    # sample n (0-based) maps to sub-chip floor((n·sn + rem0)/sd) + phase_sub; period p spans
-    # sub-chips [p·per, (p+1)·per). First sample of period p: smallest n with that sub-chip
+    _apply_secondary!(out, mc.secondary, mc.period_subchips, sn, sd, Int(phase_sub), Int(rem0), 0)
+end
+
+# Period-walk core: multiply each whole primary period covered by `out` by its secondary chip,
+# where `out`'s first sample is absolute sample `n0`. `per` = sub-chips per primary period,
+# `sn/sd` the fixed-point sub-chip step, `phase_sub` the integer sub-chip start offset (θ_int),
+# `r0` the fractional sub-chip residual. `n0 = 0` is the one-shot fill; a positive `n0`
+# continues an ongoing fill (see `_apply_secondary_continue!`).
+function _apply_secondary!(out, secondary::AbstractVector, per::Int, sn::Int, sd::Int,
+                           phase_sub::Int, r0::Int, n0::Int)
+    Ls = length(secondary); N = length(out)
+    # absolute sample n (0-based) maps to sub-chip floor((n·sn + rem0)/sd) + phase_sub; period p
+    # spans sub-chips [p·per, (p+1)·per). First sample of period p: smallest n with that sub-chip
     # ≥ p·per, i.e. n ≥ cld(T·sd − rem0, sn) (T·sd > rem0 whenever T ≥ 1, since rem0 < sd).
-    # Start at the period sample 0 falls in (A(0) = phase_sub) — NOT 0: a negative
-    # start_index_shift puts sample 0 in a negative period, and start_phase ≥ one code period
+    # Start at the period the first emitted sample (absolute n0) falls in — NOT period 0: a
+    # negative start_index_shift puts n0 in a negative period, and start_phase ≥ one code period
     # in a period ≥ 1; starting at 0 would apply the wrong secondary chip to the leading samples.
-    p = fld(phase_sub, per)
+    sub0 = (n0 * sn + r0) ÷ sd + phase_sub
+    p = fld(sub0, per)
     @inbounds while true
         T = p * per - phase_sub
-        s_p = T <= 0 ? 0 : cld(T * sd - r0, sn)
-        s_p >= N && break
+        n_start = T <= 0 ? 0 : cld(T * sd - r0, sn)     # absolute first sample of period p
+        n_start - n0 >= N && break
         Tn = (p + 1) * per - phase_sub
-        s_next = min(Tn <= 0 ? 0 : cld(Tn * sd - r0, sn), N)
-        if mc.secondary[mod(p, Ls) + 1] == -1
-            @simd for n in (s_p + 1):s_next
+        n_end = min(Tn <= 0 ? 0 : cld(Tn * sd - r0, sn), n0 + N)  # absolute end (exclusive)
+        if secondary[mod(p, Ls) + 1] == -1
+            lo = max(n_start, n0) - n0 + 1              # 1-based into out
+            hi = n_end - n0                             # 1-based inclusive
+            @simd for n in lo:hi
                 out[n] = -out[n]
             end
         end

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -628,6 +628,51 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Characterization test for the unified fixed-point arithmetic (issue #110): the windowed DDA
+# carry-advance (`_advance_phase` / `_advance_window_512` and the scalar-tail loops that now
+# call them) and the secondary-code period-walk (`_apply_secondary!` one-shot vs
+# `_apply_secondary_continue!`). Real secondary-code signals are filled at MODERATE
+# oversampling (fs = fc·P·osr with 1 < osr < 2) so every backend takes the windowed permute
+# regime — NOT the high-oversampling boundary fast path, whose DDA is separate exact
+# arithmetic. Reference = the one-shot full-length `gen_code!`; a chunked continuation whose
+# chunk sizes straddle both SIMD-window and secondary-period boundaries must reproduce it
+# byte-for-byte, cross-validating the one-shot and continuing copies of each unified routine.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "unified DDA + secondary period-walk (issue #110 characterization)" begin
+    sigs = [GPSL5I(), GPSL5Q(), GalileoE5aI(), GalileoE1C()]   # all carry a non-baked secondary
+    for signal in sigs
+        prn = 1
+        P = signal.lut.subchip_factor
+        fc = get_code_frequency(signal)
+        @test length(signal.lut.secondary) > 1                # residual (non-baked) secondary
+        for osr in (1.5, 1.75)                                 # windowed permute regime on every backend
+            fs = Float64(fc) * P * osr
+            N = 40000                                          # spans several secondary periods
+            # one-shot: windowed DDA + one-shot `_apply_secondary!` (the reference).
+            oneshot = Vector{Int8}(undef, N)
+            gen_code!(oneshot, signal, prn, fs, fc)
+            # a single warm fill (absolute offset 0) must match the one-shot exactly.
+            eng = code_engine(signal, prn, fs, fc)
+            warm = Vector{Int8}(undef, N)
+            gen_code!(warm, eng, code_state(eng))
+            @test warm == oneshot
+            # chunked continuation (offset > 0): a scalar-tail DDA advance runs at every chunk
+            # edge and `_apply_secondary_continue!` places the sign flips across call
+            # boundaries — the concatenation must equal the one big generation.
+            st = code_state(eng); got = Int8[]
+            for chunk in Iterators.cycle((1, 64, 999, 7, 16384, 63, 4096))
+                remaining = N - length(got)
+                remaining == 0 && break
+                buf = Vector{Int8}(undef, min(chunk, remaining))
+                st = gen_code!(buf, eng, st)
+                append!(got, buf)
+            end
+            @test got == oneshot
+        end
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # End-to-end fractional-phase parity against the fixed-point scalar oracle (`_ref_rem0`),
 # which IS the definition of correct embedded-LUT output (the LUT was validated byte-for-sign
 # against the original generator in prior PRs). At fractional `start_phase` /


### PR DESCRIPTION
## Summary

Closes #110. Pure cleanup: collapse two clusters of duplicated fixed-point arithmetic into a single definition each. **Behaviour is preserved exactly** — this is a prerequisite for the overflow-fix issues #102 and #108, so the numerical results are unchanged.

### 1. DDA carry-propagating advance (was 5 copies → 1 each form)

All five copies were verified line-by-line to be the identical op (rem+frac, compare-carry against the modulus, conditional subtract, phase+whole (+1 on carry), wrap at L). Kept the two canonical definitions and had the rest call them (all `@inline`, all included into the same module ⇒ zero cost):

- `_advance_phase` (iterate.jl) — canonical phase-form step.
- `_advance_window_512` (generator.jl) — canonical AVX-512 rel/scalar-base step.
- `_advance_window_phase` → forwards to `_advance_phase` (whole/frac args reordered).
- `_seed_micro_phase` → `_advance_phase` with `whole = 0` (pure fractional seed).
- `_advance_scalar_phase` → loop body is now `_advance_phase`.
- `_advance_scalar_512` → loop body is now `_advance_window_512`.

### 2. Secondary-code period-walk (was 2 copies → 1)

`_apply_secondary_continue!` (code_lut.jl) was term-for-term `CodeLUT._apply_secondary!` (modulation.jl) generalized by an absolute sample offset `n0`. Generalized the core `_apply_secondary!` with an `n0` parameter (living in CodeLUT/modulation.jl):

- one-shot wrapper calls it with `n0 = 0` (reduces to the exact previous formula, since `rem0 < step_den` ⇒ `sub0 = phase_sub`);
- `_apply_secondary_continue!` calls it with the fill state's absolute offset. The cheap no-op guard (`length(secondary) <= 1`) stays inline on the hot path.

## Why no bug-style "failing test first"

This is a behavior-preserving refactor, not a bug fix — there is no incorrect behaviour to reproduce. Instead I added a **characterization test** (`test/code_lut.jl`) that pins the exact current output of the unified paths, and confirmed it **passes both before and after** the refactor.

## Test evidence

The new test exercises real secondary-code signals (GPSL5I, GPSL5Q, GalileoE5aI, GalileoE1C — all carry a non-baked secondary) at moderate oversampling (`fs = fc·P·osr`, `1 < osr < 2`) so every backend takes the **windowed permute** DDA regime (not the high-oversampling boundary fast path, whose DDA is separate exact arithmetic). Reference = one-shot full-length `gen_code!`; a chunked continuation whose chunk sizes straddle both SIMD-window and secondary-period boundaries must reproduce it byte-for-byte — cross-validating the one-shot and continuing copies of every unified routine.

- New testset: `unified DDA + secondary period-walk (issue #110 characterization)` — **20/20 pass**, confirmed on the un-refactored base (via `git stash`) and after.
- Full suite `Pkg.test()` green, including `CodeLUT` (9954/9954), `code_engine (value-based)`, the CBOC/modulation suites, and **Aqua.jl (10/10)**.

## Unblocks

This unification is a prerequisite for the overflow fixes **#102** and **#108**: with a single carry-advance and a single period-walk, those fixes can be applied in one place each instead of five / two.