### PR TITLE
fix(code_lut): widen/re-anchor secondary-code period-walk (Int64 hang + 32-bit OOB)

### DIFF
--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -58,9 +58,13 @@ end
 function FillEngine512(table::CodeTable, step_num::Int, step_den::Int, phase_offset::Int,
                        rem0::_RemT = _RemT(0))
     L = table.length; W = 64
+    # Widen the W·step_num / 4W·step_num products to Int64: with step_num up to 2^_B = 2^30 these
+    # exceed typemax(Int32) (4·64·2^30 = 2^38), so a native-`Int` product overflows on 32-bit
+    # Julia (issue #108). The core DDA kernels already form these in Int64; match that here.
+    WSN = Int64(W) * Int64(step_num); W4SN = Int64(4W) * Int64(step_num); sdw = Int64(step_den)
     FillEngine512(table.padded, step_num, step_den, L,
-        _RemT(mod(W * step_num, step_den)), div(W * step_num, step_den) % L,
-        _RemT(mod(4W * step_num, step_den)), div(4W * step_num, step_den) % L, _RemT(step_den),
+        _RemT(mod(WSN, sdw)), Int(div(WSN, sdw) % L),
+        _RemT(mod(W4SN, sdw)), Int(div(W4SN, sdw) % L), _RemT(step_den),
         phase_offset, rem0)
 end
 
@@ -183,8 +187,10 @@ end
                                      backend::Backend, ::Val{W}, ::Type{T}, rem0::_RemT = _RemT(0)) where {W,T}
     L = table.length
     prepared = prepare_code(table; backend = backend)
+    # Int64 W·step_num (2^_B·W overflows Int32 on 32-bit Julia — issue #108; see FillEngine512).
+    WSN = Int64(W) * Int64(step_num); sdw = Int64(step_den)
     FillEnginePhase{W,T,typeof(prepared)}(prepared, step_num, step_den,
-        T(div(W * step_num, step_den) % L), _RemT(mod(W * step_num, step_den)),
+        T(Int(div(WSN, sdw) % L)), _RemT(mod(WSN, sdw)),
         _RemT(step_den), T(L), phase_offset, rem0)
 end
 

--- a/src/code_lut/modulation.jl
+++ b/src/code_lut/modulation.jl
@@ -180,17 +180,46 @@ function _apply_secondary!(out, secondary::AbstractVector, per::Int, sn::Int, sd
     # Start at the period the first emitted sample (absolute n0) falls in — NOT period 0: a
     # negative start_index_shift puts n0 in a negative period, and start_phase ≥ one code period
     # in a period ≥ 1; starting at 0 would apply the wrong secondary chip to the leading samples.
-    sub0 = (n0 * sn + r0) ÷ sd + phase_sub
-    p = fld(sub0, per)
+    #
+    # OVERFLOW SAFETY (issues #102 / #108). Two products used to overflow here:
+    #   • the seed `n0·sn` overflows Int64 once the absolute sample count n0 exceeds
+    #     typemax(Int64) ÷ sn (≈ 2^34 for GPS L5I at 20.46 MHz — ~14 min of streaming); the
+    #     seed p then wraps hugely negative and the period-walk spins ~10^6+ iterations, so
+    #     gen_code! effectively never returns (#102);
+    #   • the per-period products `T·sd` / `Tn·sd` (with sd = _STEP_DEN = 2^30) overflow native
+    #     `Int` on 32-bit Julia for any real T ≥ 2, so cld(…) turns negative and the negate loop
+    #     writes out-of-bounds (#108).
+    # Fix: (a) form the seed in Int128; (b) re-anchor the effective sub-chip phase modulo the
+    # secondary-code period Q = Ls·per sub-chips, so the running period index p — and hence
+    # every per-period product — stays bounded no matter how long streaming continues; (c) do
+    # all per-period arithmetic in explicit Int64 (never native Int), like the core DDA kernels.
+    # Re-anchoring shifts the effective phase by whole multiples of Q = Ls·per sub-chips, i.e.
+    # p by whole multiples of Ls, so `mod(p, Ls)` (the selected secondary chip) is unchanged and
+    # the output is byte-identical to the exact walk for every fill length and continuation n0.
+    snw = Int64(sn); sdw = Int64(sd); perw = Int64(per)
+    # Fold n0 (and its fractional residual r0) into an effective integer sub-chip phase at local
+    # sample 0: sub(n0+j) = floor((j·sn + R0)/sd) + phase_sub with R0 = n0·sn + r0 (Int128 seed,
+    # the only widening needed — R0 ≥ 0, so its ÷/% are non-negative).
+    R0 = Int128(n0) * snw + Int64(r0)
+    rd = Int64(R0 % sdw)                       # fractional residual at local 0, 0 ≤ rd < sd
+    qd = Int64(R0 ÷ sdw)                       # whole sub-chips absorbed (≤ n0, fits Int64)
+    Q  = Int64(Ls) * perw                      # secondary-code period, in sub-chips
+    phase0 = Int64(phase_sub) + qd             # effective integer sub-chip phase at local 0
+    phase_eff = phase0 - fld(phase0, Q) * Q    # ∈ [0, Q): strips whole multiples of Ls from p
+    # Walk periods in the local frame (first emitted sample = local sample 0, residual rd, phase
+    # phase_eff). p starts in [0, Ls) and only advances over the periods this fill spans, so
+    # p·per and T·sd stay ≤ ~Q·sd ≪ typemax(Int64).
+    sub0 = rd ÷ sdw + phase_eff                # = phase_eff (rd < sd)
+    p = fld(sub0, perw)
     @inbounds while true
-        T = p * per - phase_sub
-        n_start = T <= 0 ? 0 : cld(T * sd - r0, sn)     # absolute first sample of period p
-        n_start - n0 >= N && break
-        Tn = (p + 1) * per - phase_sub
-        n_end = min(Tn <= 0 ? 0 : cld(Tn * sd - r0, sn), n0 + N)  # absolute end (exclusive)
+        T = p * perw - phase_eff
+        n_start = T <= 0 ? Int64(0) : cld(T * sdw - rd, snw)     # local first sample of period p
+        n_start >= N && break
+        Tn = (p + 1) * perw - phase_eff
+        n_end = min(Tn <= 0 ? Int64(0) : cld(Tn * sdw - rd, snw), Int64(N))  # local end (exclusive)
         if secondary[mod(p, Ls) + 1] == -1
-            lo = max(n_start, n0) - n0 + 1              # 1-based into out
-            hi = n_end - n0                             # 1-based inclusive
+            lo = n_start + Int64(1)                    # 1-based into out (n_start ≥ 0 here)
+            hi = n_end                                  # 1-based inclusive
             @simd for n in lo:hi
                 out[n] = -out[n]
             end

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -388,6 +388,135 @@ const _BACKENDS = (CL.Portable(),
         @test CL._check_windowed_length(CL.CodeTable(ones(Int8, 8)), CL.AVX2())
         @test CL._check_windowed_length(CL.CodeTable(ones(Int8, 8)), CL.Neon())
     end
+
+    # ── secondary-code period-walk overflow (issues #102 / #108) ──────────────────────────
+    # `_apply_secondary!` walks whole primary periods, negating the samples of periods whose
+    # residual (non-baked) secondary chip is −1. It used to compute the seed `n0·sn` and the
+    # per-period products `T·sd` / `Tn·sd` in native `Int`, which overflows:
+    #   #102 (64-bit): once the absolute sample offset n0 exceeds typemax(Int64) ÷ sn (≈ 2^34
+    #        for GPS L5I at 20.46 MHz — ~14 min of streaming), n0·sn wraps hugely negative, the
+    #        seed period p goes to ≈ −10^6, and the walk spins so long that gen_code! never
+    #        returns (and T·sd overflows too, so even a returned result is wrong).
+    #   #108 (32-bit): with sd = _STEP_DEN = 2^30, `T·sd` overflows Int32 for any real T ≥ 2
+    #        (real T is thousands of sub-chips), so cld(…) turns negative → out-of-bounds writes.
+    # The fix seeds in Int128, re-anchors the phase modulo the secondary period Q = Ls·per so p
+    # stays bounded, and does every per-period product in explicit Int64 (see modulation.jl).
+    @testset "secondary period-walk overflow (#102 / #108)" begin
+        # GPS L5I NH10 residual secondary; primary 10230 chips, P = 1 ⇒ period_subchips = 10230.
+        sec = Int8[1, 1, 1, 1, -1, -1, 1, -1, 1, -1]
+        per = 10230
+        sn = 536870912; sd = 1073741824             # fs = 2·fc·P (20.46 MHz): sn = 2^29, sd = 2^30
+        # BigInt-exact reference for `out` initialised to all +1s (so out[j+1] == the sign applied
+        # to sample j): p and the sub-chip are computed exactly, so no intermediate can overflow.
+        secref(sn, sd, ps, r0, n0, N) =
+            Int8[sec[mod(fld(fld(big(n0 + j) * sn + r0, sd) + ps, per), length(sec)) + 1] for j in 0:N-1]
+
+        # #102 threshold is where n0·sn overflows Int64.
+        @test 2^34 > typemax(Int64) ÷ sn ÷ 2      # sanity: the chosen n0 (≈2^34) is near the wrap
+
+        # (1) Behaviour is unchanged for the ordinary, non-overflowing regime — including
+        # non-zero phase / fractional residual and moderate offsets (byte-identical to the exact
+        # BigInt walk). This pins that the re-anchoring did not perturb normal fills.
+        let N = 800
+            for n0 in (0, 1, 12345, 10_000_000), ps in (0, 7, 20460 + 13), r0 in (0, 555, sd - 1)
+                out = ones(Int8, N)
+                CL._apply_secondary!(out, sec, per, sn, sd, ps, r0, n0)
+                @test out == secref(sn, sd, ps, r0, n0, N)
+            end
+        end
+
+        # (2) #102: at n0 past the Int64-overflow threshold the walk must return PROMPTLY and
+        # match the exact reference. Pre-fix this hangs (never returns); a hung single-threaded
+        # compute loop cannot be interrupted cooperatively, so we run it in a child process with a
+        # wall-clock timeout — a regression fails fast (`:timeout`) instead of hanging CI. The
+        # child checks BOTH the low-level `_apply_secondary!` and the public continuing
+        # `gen_code!(out, eng, st)` path (via a large `CodeFillState.n_abs`).
+        function _run_guarded(script::String, timeout_s::Real)
+            buf = IOBuffer()
+            cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $script`
+            proc = run(pipeline(cmd; stdout = buf, stderr = devnull); wait = false)
+            timedout = Ref(false)
+            timer = Timer(timeout_s) do _
+                process_running(proc) && (timedout[] = true; kill(proc))
+            end
+            wait(proc); close(timer)
+            timedout[] ? (:timeout, "") : (:done, String(take!(buf)))
+        end
+        # Wrapped in a function so the child's top-level `for` loops don't hit `-e` soft-scope.
+        script = """
+        using GNSSSignals
+        const CL = GNSSSignals.CodeLUT
+        function main()
+            sec = Int8[1,1,1,1,-1,-1,1,-1,1,-1]; per = 10230; sn = 536870912; sd = 1073741824
+            N = 1000
+            sref(n0) = Int8[sec[mod(fld(fld(big(n0+j)*sn, sd), per), length(sec))+1] for j in 0:N-1]
+            ok = true
+            # low-level period walk, well past the Int64 seed-overflow threshold
+            for n0 in (2^34 + 12345, 5*2^34 + 777, 2^40 + 3)
+                out = ones(Int8, N)
+                CL._apply_secondary!(out, sec, per, sn, sd, 0, 0, n0)
+                ok &= (out == sref(n0))
+            end
+            # public continuing path: a CodeFillState with huge n_abs drives _apply_secondary_continue!
+            eng = code_engine(GPSL5I(), 1, 20.46e6)
+            st0 = code_state(eng)
+            big_n = 2^34 + 100000
+            base = zeros(Int8, N); gen_code!(base, eng, st0)              # secondary applied at offset 0
+            outb = zeros(Int8, N); gen_code!(outb, eng, GNSSSignals.CodeFillState(st0.dda, big_n))
+            ps = eng.phase_sub; r0 = eng.rem0; s = Int.(eng.secondary); L = eng.period_subchips
+            sgn(n0, j) = s[mod(fld(fld(big(n0+j)*sn + r0, sd) + ps, L), length(s)) + 1]
+            # outb[j]==raw[j]*sgn(big_n,j), base[j]==raw[j]*sgn(0,j) ⇒ outb == base*sgn(0)*sgn(big_n)
+            refb = Int8[base[j+1] * sgn(0, j) * sgn(big_n, j) for j in 0:N-1]
+            ok &= (outb == refb)
+            ok &= all(x -> x == 1 || x == -1, outb)                      # in-bounds, valid ±1
+            ok
+        end
+        println(main() ? "OK" : "FAIL")
+        """
+        status, output = _run_guarded(script, 90)
+        @test status == :done                 # returned promptly (a hang regression ⇒ :timeout)
+        @test strip(output) == "OK"            # matches the BigInt-exact reference
+
+        # (3) #108: the products that overflow native `Int` on 32-bit Julia. `T·sd` and the
+        # fill-engine `W·step_num` both exceed typemax(Int32); the fix computes them in Int64.
+        # We can't run 32-bit Julia here, so assert (a) the native-Int32 product IS wrong
+        # (documents the bug) and (b) the widened path yields the exact Int64 result.
+        @test Int32(2) * Int32(sd) != Int64(2) * Int64(sd)           # T·sd overflows Int32 at T≥2
+        @test Int32(2) * Int32(sd) < 0                                # …to a negative index → OOB
+        @test Int32(per) * Int32(sd) != Int64(per) * Int64(sd)       # real per-period T·sd overflows
+        # `_apply_secondary!` (small n0, so #102 re-anchoring is not what's under test) still
+        # matches the exact walk for a signal whose per·sd overflows Int32 — i.e. the per-period
+        # product is done in Int64.
+        let N = 500
+            @test Int64(per) * Int64(sd) > typemax(Int32)
+            for n0 in (0, 250, 9999)
+                out = ones(Int8, N)
+                CL._apply_secondary!(out, sec, per, sn, sd, 0, 0, n0)
+                @test out == secref(sn, sd, 0, 0, n0, N)
+            end
+        end
+        # Fill-engine constructor `W·step_num` widening (issue #108): with step_num up to 2^_B,
+        # 4·64·step_num = 2^38 overflows Int32. FillEngine512 (W = 64) is pure construction-time
+        # arithmetic (host-independent). Its stored per-window / per-stride deltas must equal the
+        # Int64 reference; a native-Int32 W·step_num would be negative/wrong.
+        let sn2 = 2^30 - 12345, sd2 = 2^30
+            table = CL.CodeTable(ones(Int8, 10230)); L = table.length
+            @test Int32(64) * Int32(sn2) < 0                          # W·step_num overflows Int32
+            @test Int32(4 * 64) * Int32(sn2) < 0                      # 4W·step_num overflows Int32
+            e = CL.FillEngine512(table, sn2, sd2, 0)
+            @test e.whole_W      == Int(div(Int64(64)  * sn2, Int64(sd2)) % L)
+            @test e.frac_W       == mod(Int64(64)  * sn2, Int64(sd2))
+            @test e.whole_stride == Int(div(Int64(256) * sn2, Int64(sd2)) % L)
+            @test e.frac_stride  == mod(Int64(256) * sn2, Int64(sd2))
+            # Phase engine (AVX2/NEON/Portable path): its stored deltas match the Int64 reference
+            # for its own window width W (Portable ⇒ W = 1; the W·step_num arithmetic is widened
+            # identically for the W = 16/32 SIMD widths).
+            ep = CL.FillEnginePhase(table, sn2, sd2, 0, CL.Portable(), Val(1))
+            W = typeof(ep).parameters[1]
+            @test Int(ep.whole_W) == Int(div(Int64(W) * sn2, Int64(sd2)) % L)
+            @test ep.frac_W       == mod(Int64(W) * sn2, Int64(sd2))
+        end
+    end
 end
 
 


### PR DESCRIPTION
## Summary

Fixes two overflow bugs in the unified secondary-code period-walk (`_apply_secondary!` in `src/code_lut/modulation.jl`, shared by the one-shot fill and the continuing `_apply_secondary_continue!`). Both live in the **same** lines the #110 unification created, so they are fixed together.

- **#102 (64-bit hang):** the seed product `n0·sn` overflows `Int64` once the absolute sample offset exceeds `typemax(Int64) ÷ sn` (≈ `2^34` for GPS L5I at 20.46 MHz — ~14 min of continuous streaming). The seed period `p` wraps hugely negative and the `while true` walk spins ~10⁶⁺ iterations (and `T·sd` overflows as well), so `gen_code!` effectively never returns.
- **#108 (32-bit OOB):** with `sd = _STEP_DEN = 2^30`, the per-period product `T·sd` overflows native `Int` on 32-bit Julia for any real `T ≥ 2` (real `T` is thousands of sub-chips), so `cld(…)` turns negative and the `@inbounds` negate loop writes out-of-bounds.

## Fix (one coherent change)

1. Form the seed `n0·sn + r0` in **`Int128`** (the only widening the seed needs).
2. **Re-anchor** the effective sub-chip phase modulo the secondary-code period `Q = Ls·per` sub-chips, so the running period index `p` — and hence every per-period product — stays bounded no matter how long streaming continues. Shifting the phase by whole multiples of `Q = Ls·per` shifts `p` by whole multiples of `Ls`, so `mod(p, Ls)` (the selected secondary chip) is unchanged → **byte-identical output** for every fill length and continuation offset.
3. Do all per-period arithmetic in **explicit `Int64`** (never native `Int`), matching the core DDA kernels (`kernel.jl` / `generator.jl`).

Also widened the `W·step_num` / `4W·step_num` products in the `FillEngine512` / `FillEnginePhase` constructors to `Int64` (`4·64·2^30 = 2^38` overflows `Int32` too — the other 32-bit site called out in #108).

## Failing-test-first evidence

New testset `secondary period-walk overflow (#102 / #108)` in `test/code_lut.jl`:

- **#102** runs the walk at `n0` past the `Int64` threshold — both the low-level `_apply_secondary!` and the public `gen_code!(out, eng, st)` path (via a large `CodeFillState.n_abs`) — in a **child process with a wall-clock timeout**, because a hung single-threaded compute loop can't be interrupted cooperatively. Pre-fix this returns `:timeout` (the 2 failing assertions captured on the pre-fix tree); post-fix it returns promptly and matches a BigInt-exact reference.
- **#108** asserts the native-`Int32` products (`T·sd`, `W·step_num`) overflow to negative/wrong values (documents the 32-bit bug we can't execute here) and that the widened path matches the exact `Int64`/`BigInt` result; plus a `FillEngine512` construction check.
- Moderate-offset **regression locks** confirm normal (non-overflowing) fills are byte-identical to the exact walk (and to the pre-fix implementation).

Full suite (incl. Aqua) passes locally.

Stacked on #110 (#121) — base is `fix/110-unify-dda-periodwalk` because #110 removed the duplicate period-walk so the arithmetic is fixed in one place. GitHub will auto-retarget to `feat/code-lut-resampler` when #110 merges.

Closes #102
Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)