### PR TITLE
docs(code_lut): correct stale Int16/Float32 output claims and removed negated-codes cache

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -230,12 +230,12 @@ get_modulation(gal_e1c)            # CBOC(BOCsin(1,1), BOCsin(6,1), 10/11, -1)
 
 The secondary code is shared across all PRNs, so [`get_secondary_code`](@ref) returns a [`SharedSecondaryCode`](@ref GNSSSignals.SharedSecondaryCode) of length 25. As with E1B, CBOC modulation makes the code values floating-point.
 
-A [`GalileoE1C_BOC11`](@ref GNSSSignals.GalileoE1C_BOC11) variant provides the BOC(1,1) approximation (Int16 output, lower sampling rate) — the same substitution PocketSDR uses for E1C by default — with identical primary and CS25 secondary codes:
+A [`GalileoE1C_BOC11`](@ref GNSSSignals.GalileoE1C_BOC11) variant provides the BOC(1,1) approximation (lower minimum sampling rate) — the same substitution PocketSDR uses for E1C by default — with identical primary and CS25 secondary codes:
 
 ```julia
 e1c = GalileoE1C_BOC11()
 get_modulation(e1c)          # BOCsin(1, 1)
-get_code_type(e1c)           # Int16
+get_code_type(e1c)           # Int16  (the get_code accessor type; gen_code! is Int8)
 ```
 
 ### Galileo E5a-I

--- a/src/galileo/e1b.jl
+++ b/src/galileo/e1b.jl
@@ -159,12 +159,14 @@ BOC(1,1) and BOC(6,1) requiring fs ≥ 2 · 6 · 1.023 MHz to fully
 sample. Many software receivers substitute a pure BOC(1,1) replica
 because (a) the BOC(6,1) component carries only 1/11 of the signal
 power, so the correlation loss is ≈ 0.45 dB, and (b) BOC(1,1) needs
-only fs ≥ 2 · 1.023 MHz, allowing lower sampling rates and Int16
-output. PocketSDR, for example, uses this substitution by default
+only fs ≥ 2 · 1.023 MHz, allowing lower sampling rates.
+PocketSDR, for example, uses this substitution by default
 (see `mod_code` in `sdr_code.c`).
 
-Use this type when you want the lower sampling-rate, Int16-output
-variant; use [`GalileoE1B`](@ref) for the full CBOC spec output (Float32).
+Use this type when you want the lower sampling-rate variant; use
+[`GalileoE1B`](@ref) for the full CBOC spec approximation. Either way
+`gen_code!` emits `Int8` — only the single-chip [`get_code`](@ref)
+accessor returns `Float32` (`get_code_type` is `Int16` here).
 
 Primary code, code length, code frequency, data rate, and band are
 identical to [`GalileoE1B`](@ref); only `get_modulation` differs.

--- a/src/galileo/e1c.jl
+++ b/src/galileo/e1c.jl
@@ -17,10 +17,6 @@ E1C differs from [`GalileoE1B`](@ref) in three ways:
 - Its CBOC uses the BOC(6,1) component in *anti-phase* — CBOC(−) — per the
   Galileo OS SIS ICD §2.3.3, where E1-B uses CBOC(+).
 
-The struct caches an element-wise negated primary-code matrix so that
-`gen_code!` can hoist the per-secondary-chip sign multiply out of the inner
-loop (the same trick used for [`GPSL5I`](@ref)).
-
 # Example
 ```julia
 e1c = GalileoE1C()
@@ -182,12 +178,14 @@ BOC(1,1) and BOC(6,1) requiring fs ≥ 2 · 6 · 1.023 MHz to fully sample.
 Many software receivers substitute a pure BOC(1,1) replica because (a) the
 BOC(6,1) component carries only 1/11 of the signal power, so the
 correlation loss is ≈ 0.45 dB, and (b) BOC(1,1) needs only
-fs ≥ 2 · 1.023 MHz, allowing lower sampling rates and Int16 output.
+fs ≥ 2 · 1.023 MHz, allowing lower sampling rates.
 PocketSDR, for example, uses this substitution for E1C by default (see
 `gen_code_E1C` in `sdr_code.c`).
 
-Use this type when you want the lower sampling-rate, Int16-output variant;
-use [`GalileoE1C`](@ref) for the full CBOC spec output (Float32).
+Use this type when you want the lower sampling-rate variant; use
+[`GalileoE1C`](@ref) for the full CBOC spec approximation. Either way
+`gen_code!` emits `Int8` — only the single-chip [`get_code`](@ref)
+accessor returns `Float32` (`get_code_type` is `Int16` here).
 
 Primary code, code length, secondary code (CS25), code frequency, data
 rate, and band are identical to [`GalileoE1C`](@ref); only `get_modulation`

--- a/src/galileo/e5a.jl
+++ b/src/galileo/e5a.jl
@@ -47,9 +47,8 @@ BPSK(10) ([`LOC`](@ref)). The primary code uses the same generator as E5a-I
 the E5a-Q per-SVID register-2 start values `E5A_Q_X2_INIT`. PRNs 1-50 are
 supported.
 
-The struct also caches an element-wise negated primary-code matrix (the trick
-used by [`GPSL5I`](@ref) and [`GPSL1C_P`](@ref)) and stores the CS100 overlay
-matrix, exposed via [`get_secondary_code`](@ref) as a [`PerPRNSecondaryCode`](@ref).
+The struct stores the CS100 overlay matrix, exposed via
+[`get_secondary_code`](@ref) as a [`PerPRNSecondaryCode`](@ref).
 
 # Example
 ```julia


### PR DESCRIPTION
## Summary

Fixes stale pre-LUT documentation flagged in #127. Since the LUT resampler landed, `gen_code!`/`gen_code` emit `Int8` (only the single-chip `get_code` accessor stays `Float32`), and the element-wise negated primary-code cache was removed (the structs are now `codes`/`lut` and `codes`/`secondary_codes`/`lut`). Several user-facing docs still advertised the old behaviour — a user following them would allocate an `Int16` buffer and hit a `MethodError`.

## Edits (all docs/comments only)

1. **`docs/src/usage.md`** — the `GalileoE1C_BOC11` blurb no longer claims "Int16 output"; the code-block comment now clarifies `get_code_type` is the accessor type while `gen_code!` is `Int8` (mirrors the already-updated E1B_BOC11 wording).
2. **`src/galileo/e1c.jl`** (`GalileoE1C_BOC11` docstring) — replaced "allowing lower sampling rates and Int16 output" / "full CBOC spec output (Float32)" with the Int8-only `gen_code!` reality.
3. **`src/galileo/e1b.jl`** (`GalileoE1B_BOC11` docstring) — same Int16/Float32 correction, keeping the two `_BOC11` docstrings parallel and internally consistent.
4. **`src/galileo/e1c.jl`** (`GalileoE1C` docstring) — dropped the negated-primary-code-cache paragraph (field removed; struct is `codes`/`lut`).
5. **`src/galileo/e5a.jl`** (`GalileoE5aQ` docstring) — dropped the negated-cache paragraph and the retired GPSL5I/GPSL1C_P trick reference (struct is `codes`/`secondary_codes`/`lut`).

## Testing

`Pkg.test()` passes locally (docs/comment-only change; no behaviour touched).

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)