### PR TITLE
fix(code_lut): AVX2 runtime feature re-check + dedup default_backend to _select_backend

### DIFF
--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -110,21 +110,25 @@ include("code_lut/generator.jl")
     # depot, Docker/CI) where issuing `vpermb` SIGILLs (#104). So inside that branch we consult
     # the RUNTIME-detected feature set (`RUNTIME_FEATURES`, populated in `__init__`) and demote
     # AVX512 -> AVX2/Portable when the running CPU lacks VBMI. The AVX2-only precompile branch
-    # likewise re-checks avx2 at runtime. The fast path for genuinely-capable CPUs is preserved.
+    # likewise re-checks avx2 at runtime, demoting AVX2 -> Portable on a non-AVX2 CPU (#126). The
+    # fast path for genuinely-capable CPUs is preserved.
     @static if HOST_FEATURES.avx512vbmi
         # Precompiled on a VBMI host → the AVX-512 path IS compiled. This is the only branch
-        # that can OVER-claim (#104): the pkgimage may load on a non-VBMI CPU where `vpermb`
-        # SIGILLs. Consult the RUNTIME features and demote AVX512 -> AVX2/Portable when the live
-        # CPU lacks VBMI. Costs one Ref load per call (off the hot path); AVX-512 hosts are rare.
-        default_backend() =
-            RUNTIME_FEATURES[].avx512vbmi ? AVX512() :
-            RUNTIME_FEATURES[].avx2       ? AVX2()   : Portable()
+        # that can OVER-claim VBMI (#104): the pkgimage may load on a non-VBMI CPU where `vpermb`
+        # SIGILLs. Delegate to `_select_backend` (the unit-tested selection policy) applied to the
+        # RUNTIME features so the shipping path can't drift from the tested helper (#129); it
+        # demotes AVX512 -> AVX2/Portable when the live CPU lacks VBMI. Costs one Ref load per
+        # call (off the hot path); AVX-512 hosts are rare.
+        default_backend() = _select_backend(RUNTIME_FEATURES[])
     elseif HOST_FEATURES.avx2
-        # Precompiled without AVX-512: the AVX-512 path is dead code (never compiled — its
-        # `<64 x i8>` vpermb cannot be legalised on a non-AVX-512 target). AVX-512 VBMI is the
-        # only feature #104 concerns, and there is nothing here that could pick it, so we
-        # const-fold to AVX2 exactly as before — no Ref read, preserving the common fast path.
-        default_backend() = AVX2()
+        # Precompiled without AVX-512: the AVX-512 `vpermb` path is dead code (never compiled —
+        # its `<64 x i8>` op cannot be legalised on a non-AVX-512 target), so this branch must
+        # never return AVX512(). But AVX2 itself can OVER-claim exactly like #104, one tier down:
+        # with JULIA_CPU_TARGET=generic the native code loads on a CPU without AVX2, where the
+        # AVX2 `_pshufb` (an llvmcall forcing +avx2) SIGILLs (#126). So re-check the RUNTIME
+        # feature set and demote AVX2 -> Portable when the live CPU lacks AVX2. One Ref load per
+        # call; choose only between AVX2/Portable (the AVX-512 path is not compiled here).
+        default_backend() = RUNTIME_FEATURES[].avx2 ? AVX2() : Portable()
     else
         default_backend() = Portable()
     end

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -1073,23 +1073,54 @@ end
             # __init__ populated the runtime feature Ref with the CPU actually executing.
             @test CL.RUNTIME_FEATURES[] == CL._x86_features()
 
-            # The AVX-512 path is compiled/selectable ONLY when this build was precompiled on a
-            # VBMI host (the `@static` gate on HOST_FEATURES — otherwise its <64 x i8> `vpermb`
-            # can't be legalised and even compiling it aborts LLVM). That is also the only build
-            # that can over-claim, so the runtime demotion (#104) lives there and is exercised on
-            # the AVX-512 SDE CI job. On a non-VBMI build the guarantee is stronger and static:
-            # AVX-512 is const-folded away, so gen_code! can never emit `vpermb`.
+            # Which `@static` branch of `default_backend()` was COMPILED depends on this build's
+            # precompile host (the `@static if HOST_FEATURES.*` gate). We can't recompile here, so
+            # each branch's runtime re-check (#104/#126) is exercised by pointing the runtime Ref
+            # at simulated feature sets — `default_backend()` reads `RUNTIME_FEATURES[]` live, so
+            # this drives the exact shipping selection as a pure function of a feature value.
             if CL.HOST_FEATURES.avx512vbmi
-                @test CL.default_backend() === CL._select_backend(CL.RUNTIME_FEATURES[])
-                # Simulate a VBMI-baked pkgimage loaded on a non-VBMI CPU by pointing the runtime
-                # Ref at a non-VBMI feature set: selection must demote rather than emit `vpermb`.
+                # #129: the shipping AVX-512 branch IS `_select_backend(RUNTIME_FEATURES[])` — no
+                # hand-inlined feature→backend ternary that could drift from the tested helper.
+                # Assert the two agree across EVERY simulated feature set, so any future policy
+                # change in `_select_backend` is automatically reflected in the shipping path.
                 saved = CL.RUNTIME_FEATURES[]
                 try
+                    for feats in ((avx2 = false, avx512vbmi = false),
+                                  (avx2 = true,  avx512vbmi = false),
+                                  (avx2 = true,  avx512vbmi = true))
+                        CL.RUNTIME_FEATURES[] = feats
+                        @test CL.default_backend() === CL._select_backend(feats)
+                    end
+                    # Explicit #104 demotions: a VBMI-baked pkgimage loaded on a lesser CPU must
+                    # demote rather than emit `vpermb`.
                     CL.RUNTIME_FEATURES[] = (avx2 = true, avx512vbmi = false)
                     @test !(CL.default_backend() isa CL.AVX512)
                     @test CL.default_backend() isa CL.AVX2
                     CL.RUNTIME_FEATURES[] = (avx2 = false, avx512vbmi = false)
                     @test CL.default_backend() isa CL.Portable
+                finally
+                    CL.RUNTIME_FEATURES[] = saved
+                end
+            elseif CL.HOST_FEATURES.avx2
+                # #126: the AVX2-only precompile branch must RE-CHECK avx2 at runtime, mirroring
+                # the AVX-512 branch's #104 demotion one tier down. With JULIA_CPU_TARGET=generic
+                # an AVX2-baked pkgimage can load on a CPU without AVX2, where the AVX2 `_pshufb`
+                # (an llvmcall forcing +avx2) SIGILLs; selection must demote AVX2 -> Portable.
+                # (Before the fix this branch const-folded to `AVX2()`, ignoring the runtime Ref —
+                # so the avx2=false case below returned AVX2() and FAILED.)
+                saved = CL.RUNTIME_FEATURES[]
+                try
+                    CL.RUNTIME_FEATURES[] = (avx2 = false, avx512vbmi = false)
+                    @test CL.default_backend() isa CL.Portable
+                    @test !(CL.default_backend() isa CL.AVX2)
+                    CL.RUNTIME_FEATURES[] = (avx2 = true, avx512vbmi = false)
+                    @test CL.default_backend() isa CL.AVX2
+                    # The AVX-512 path is NOT compiled on an AVX2-only build, so even a
+                    # VBMI-capable runtime must select AVX2 here — never AVX512() (its `vpermb`
+                    # would SIGILL on code that was never legalised for this target).
+                    CL.RUNTIME_FEATURES[] = (avx2 = true, avx512vbmi = true)
+                    @test CL.default_backend() isa CL.AVX2
+                    @test !(CL.default_backend() isa CL.AVX512)
                 finally
                     CL.RUNTIME_FEATURES[] = saved
                 end


### PR DESCRIPTION
Both issues live in the same `@static` x86 block of `default_backend()` in `src/code_lut.jl`, so they are fixed together.

## #126 — AVX2-precompile branch must re-check features at runtime (SIGILL fix)
The AVX2-only precompile branch const-folded to `AVX2()` with **no runtime re-check**, leaving the relocated-pkgimage over-claim hole (#104, closed for AVX-512) open one tier down. `HOST_FEATURES` is a precompile-time const; with `JULIA_CPU_TARGET=generic` the native code can load on a CPU without AVX2 while the const still claims `avx2=true`, and `_pshufb` (an llvmcall forcing `+avx2`) then **SIGILLs**. The top comment even *claimed* this re-check already happened, contradicting the code.

Fix: mirror the AVX-512 branch's #104 demotion using existing machinery (`__init__`/`_refresh_host_features!`/`RUNTIME_FEATURES`):
```julia
default_backend() = RUNTIME_FEATURES[].avx2 ? AVX2() : Portable()
```
The AVX-512 `vpermb` path is **not compiled** on an AVX2 build, so this chooses only between AVX2/Portable — never `AVX512()`. The contradicting comment is fixed to match.

## #129 — dedup the AVX-512 branch to `_select_backend`
The AVX-512 branch hand-inlined the feature→backend ternary that `_select_backend(features)` already provides (and `test/code_lut.jl` unit-tests), so the shipping path could drift from the tested helper. Fix:
```julia
default_backend() = _select_backend(RUNTIME_FEATURES[])
```
Verified drop-in: same single Ref read, same small `Union{AVX512,AVX2,Portable}` return — inference/precompile unchanged. `_select_backend` is defined before use (permute.jl is included above). The small Union is kept intentionally.

## Tests (failing-first)
- **#129**: strengthened the existing `#104` testset to assert `default_backend() === _select_backend(RUNTIME_FEATURES[])` across **every** simulated feature set, so a future policy change in the helper is automatically reflected in the shipping path.
- **#126**: added an AVX2-branch arm (gated on `HOST_FEATURES.avx2`, which is what the native CI matrix runners are) asserting that `avx2=false` demotes to **`Portable()` (not `AVX2()`)**, `avx2=true` gives `AVX2()`, and a VBMI-capable runtime still yields `AVX2()` (never `AVX512()`) on an AVX2 build.

The `#126` assertion fails on the pre-fix code (the const-folded branch ignores the runtime Ref and returns `AVX2()` for `avx2=false`) and passes after the fix. Full local suite passes (CodeLUT: 10020 tests, Aqua included) on this AVX-512 VBMI host; the AVX2-branch arm runs on the native (AVX2-only) CI matrix and the AVX-512 arm on the SDE Ice-Lake job.

Closes #126
Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)