### PR TITLE
refactor(code_lut): unify the boundary store-width ladder

### DIFF
--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -276,18 +276,17 @@ function FillEngineBoundary(table::CodeTable, step_num::Int, step_den::Int, phas
     c0 = Int(mod(Int64(rem0) >> _B + phase_offset, table.length))
     r0 = _RemT(Int64(rem0) & Int64(step_den - 1))
     m = _STEP_DEN ÷ step_num
-    if m <= 6
-        FillEngineBoundary{8,false}(table.padded, table.length, step_num, c0, r0)
-    elseif m <= 14
-        FillEngineBoundary{16,false}(table.padded, table.length, step_num, c0, r0)
-    elseif m <= 30
-        FillEngineBoundary{32,false}(table.padded, table.length, step_num, c0, r0)
-    elseif m <= 62
-        FillEngineBoundary{64,false}(table.padded, table.length, step_num, c0, r0)
-    else
-        FillEngineBoundary{64,true}(table.padded, table.length, step_num, c0, r0)
+    # Same rung → (store width, EXTRAS) ladder as `_boundary_dispatch!`, shared via the one
+    # `_with_boundary_width` helper (issue #130) so the two sites can never silently desync.
+    # `_build_boundary` recovers `SW`/`EXTRAS` by dispatch so the stored `Val`s stay concrete.
+    _with_boundary_width(m) do sw, extras
+        _build_boundary(sw, extras, table.padded, table.length, step_num, c0, r0)
     end
 end
+
+@inline _build_boundary(::Val{SW}, ::Val{EXTRAS}, padded, L::Int, step_num::Int, c0::Int,
+                        r0::_RemT) where {SW,EXTRAS} =
+    FillEngineBoundary{SW,EXTRAS}(padded, L, step_num, c0, r0)
 
 @inline fill_state(eng::FillEngineBoundary) = BoundaryState(eng.c0, eng.r0)
 

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -565,18 +565,34 @@ end
 # SW = 8 rung matters on store-bandwidth-limited cores (CI runners): at m ≈ 5 a 16-wide
 # store is 3.3× write amplification vs 8-wide's 1.6× (measured 1.4–1.6× on the ubuntu
 # benchmark's GPSL1CA @ 5 MHz row).
+#
+# The rung → (store width, EXTRAS) mapping lives here in one place and is shared by both
+# selection sites (this dispatch and the `FillEngineBoundary` constructor in generator.jl,
+# issue #130). Because the choice never affects output, retuning it at only one site would
+# silently desync one-shot `gen_code!` from the continuing `code_engine` for the same rate —
+# uncatchable by output tests. CPS style (`f` fed the `Val`s) rather than a plain
+# `m -> (Val, Val)` return: five distinct `Val` pairs would form a 5-way union, past Julia's
+# union-splitting limit of 4, forcing dynamic dispatch in `_boundary_dispatch!`. As a
+# `@inline`d continuation `f` is inlined into each branch, so the `Val`s stay compile-time
+# constants — the dispatch stays type-stable and the constructor still stores a concrete `Val`.
+@inline function _with_boundary_width(f::F, m::Int) where {F}
+    if m <= 6
+        f(Val(8), Val(false))
+    elseif m <= 14
+        f(Val(16), Val(false))
+    elseif m <= 30
+        f(Val(32), Val(false))
+    elseif m <= 62
+        f(Val(64), Val(false))
+    else
+        f(Val(64), Val(true))
+    end
+end
+
 @inline function _boundary_dispatch!(out, padded, L::Int, SN::Int64, c0::Int, r0::Int64)
     m = _STEP_DEN ÷ Int(SN)
-    if m <= 6
-        _boundary_fill!(out, padded, L, SN, c0, r0, Val(8), Val(false))
-    elseif m <= 14
-        _boundary_fill!(out, padded, L, SN, c0, r0, Val(16), Val(false))
-    elseif m <= 30
-        _boundary_fill!(out, padded, L, SN, c0, r0, Val(32), Val(false))
-    elseif m <= 62
-        _boundary_fill!(out, padded, L, SN, c0, r0, Val(64), Val(false))
-    else
-        _boundary_fill!(out, padded, L, SN, c0, r0, Val(64), Val(true))
+    _with_boundary_width(m) do sw, extras
+        _boundary_fill!(out, padded, L, SN, c0, r0, sw, extras)
     end
     nothing
 end

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -250,6 +250,54 @@ const _BACKENDS = (CL.Portable(),
         end
     end
 
+    @testset "boundary store-width ladder: one-shot == continuing across all five rungs (#130)" begin
+        # The rung → (store width, EXTRAS) ladder is a pure speed choice — every variant is
+        # exact for every rate, so it can NEVER change the output. That's exactly why it's
+        # dangerous: it lives in one shared helper (`_with_boundary_width`) feeding BOTH the
+        # one-shot `_generate_boundary!` dispatch and the continuing `FillEngineBoundary` ctor,
+        # and a retune at only one site would silently pick different store widths for the same
+        # rate — byte-identical output, so the exact-vs-oracle tests (which never pit the two
+        # paths against each other) could never notice. This characterization pins the two
+        # sites to agree for a rate in EVERY rung. Not a bug-style failing test: the refactor is
+        # behaviour-preserving, so it passes before and after — its job is to catch a FUTURE
+        # desync, which is uncatchable by output-vs-oracle checks.
+        rng = MersenneTwister(1300)
+        L = 1023; chips = rand(rng, Int8[-1, 1], L); ct = CL.CodeTable(chips)
+        # one cps per rung: m = _STEP_DEN ÷ step_num lands in ≤6, ≤14, ≤30, ≤62, >62.
+        seen = Set{Tuple{Int,Bool}}()
+        for cps in (1 / 4, 1 / 10, 1 / 20, 1 / 50, 1 / 100)
+            sn = _step_num(cps); m = _SD ÷ sn
+            # mirror of the shared ladder, only to assert the sweep really spans all five rungs
+            push!(seen, m <= 6  ? (8, false)  : m <= 14 ? (16, false) : m <= 30 ? (32, false) :
+                        m <= 62 ? (64, false) : (64, true))
+            for phase in (0, L - 1), rem0 in (0, _SD ÷ 3, _SD - 1)
+                n = 4096
+                ref = _ref_rem0(chips, sn, rem0, phase, n)
+                # one-shot: `_generate_boundary!` → `_boundary_dispatch!` selection site
+                oneshot = Vector{Int8}(undef, n)
+                CL._generate_boundary!(oneshot, ct, sn, _SD, phase, CL._RemT(rem0))
+                # continuing: `FillEngineBoundary` ctor selection site, across uneven chunks
+                eng = CL.FillEngineBoundary(ct, sn, _SD, phase, CL._RemT(rem0)); st = CL.fill_state(eng)
+                cont = Int8[]
+                for chunk in (700, 1, 1000, 64, n - 700 - 1 - 1000 - 64)
+                    buf = Vector{Int8}(undef, chunk); st = CL.fill_continue!(buf, eng, st); append!(cont, buf)
+                end
+                @test oneshot == ref
+                @test cont == oneshot          # the two selection sites agree byte-for-byte
+            end
+        end
+        # the sweep really did walk all five rungs (both sites share this same ladder)
+        @test seen == Set([(8, false), (16, false), (32, false), (64, false), (64, true)])
+
+        # After the CPS refactor `_boundary_dispatch!` must stay type-stable: the `@inline`d
+        # `_with_boundary_width` inlines its continuation so no 5-way `Val` union / dynamic
+        # dispatch leaks in (that was the whole reason for CPS over `m -> (Val, Val)`).
+        out = Vector{Int8}(undef, 256); pad = ct.padded
+        @inferred CL._boundary_dispatch!(out, pad, ct.length, Int64(_step_num(1 / 20)), 0, Int64(0))
+        # …and the ctor still stores a concrete `Val` (no abstractly-typed engine field).
+        @test isconcretetype(typeof(CL.FillEngineBoundary(ct, _step_num(1 / 20), _SD, 0, CL._RemT(0))))
+    end
+
     @testset "fractional sub-chip start phase (rem0) — all backends == shifted reference" begin
         # A fixed-point fractional sub-chip offset `rem0 ∈ [0, 2^_B)` seeds the DDA's running
         # remainder so it tracks the SHIFTED stream `((step_num·n + rem0) >> _B + phase)`. Every


### PR DESCRIPTION
## Summary

The five-rung boundary store-width ladder — `m = _STEP_DEN ÷ step_num` mapped to `m ≤ 6 → 8`, `≤ 14 → 16`, `≤ 30 → 32`, `≤ 62 → 64`, else `64 + EXTRAS` — was **duplicated** in two places:

- `FillEngineBoundary(table, …)` constructor (`src/code_lut/generator.jl`) — the continuing `code_engine` / `fill_continue!` path
- `_boundary_dispatch!` (`src/code_lut/kernel.jl`) — the one-shot `gen_code!` path

Per the kernel comment the choice is a pure store-width (speed) pick and **cannot change the output** — every variant is exact for every rate. That's exactly what makes the duplication dangerous: retuning the rungs at only one site would silently send one-shot `gen_code!` and continuing `code_engine` to *different* store widths for the same rate, with byte-identical output, so no output-vs-oracle test could ever catch the drift (same spirit as the resolved #110).

## Fix

Both sites now route through one shared helper `_with_boundary_width(f, m)` (kernel.jl). It is **CPS-style** (`f` is fed the `Val`s) rather than a plain `m -> (Val(SW), Val(EXTRAS))` return, because five distinct `Val` pairs form a 5-way union — past Julia's union-splitting limit of 4 — which would force dynamic dispatch in `_boundary_dispatch!`. As an `@inline` continuation, `f` inlines into each branch, so the `Val`s stay compile-time constants.

Thresholds, mapping, and numerical output are **unchanged**.

## Type-stability / no-regression evidence

- `@code_typed _generate_boundary!` (optimized): no closure `%new`, no dynamic invoke of `_with_boundary_width`, `_boundary_fill!` fully inlined with compile-time-constant `Val`s.
- Allocation at the real entry point `_generate_boundary!` is identical to the pre-refactor baseline (16 B measurement overhead, all rungs).
- `FillEngineBoundary` still constructs a **concrete** engine type (`isconcretetype == true`).

## Test

Added a characterization testset (`test/code_lut.jl`) that:
- sweeps one rate per rung (asserting the sweep really covers all five `(SW, EXTRAS)` pairs), and pins one-shot `_generate_boundary!` to agree **byte-for-byte** with the continuing `FillEngineBoundary` + `fill_continue!` (across uneven chunks) and with the scalar oracle;
- asserts `@inferred` type-stability of `_boundary_dispatch!` and concreteness of the constructed engine.

This is a behaviour-preserving refactor, so it is a **characterization** (passes before and after) rather than a bug-style failing test — its job is to catch a *future* one-site retune, which output-vs-oracle checks cannot.

Full suite passes locally (incl. Aqua).

Closes #130