### PR TITLE
fix(code_lut): validate K in code_engine(Val(K)) and widen _phase_type margin

### DIFF
--- a/src/code_lut/iterate.jl
+++ b/src/code_lut/iterate.jl
@@ -136,6 +136,15 @@ end
 function _make_engine(table::CodeTable, sn, sd, ph, rem0::_RemT, ::Val{K}, backend, ::Val{W}) where {K,W}
     backend isa Union{AVX2,Neon} && _check_windowed_length(table, backend)
     stride = K * W; L = table.length; T = _phase_type(L)
+    # `code_state(eng, stream)` seeds the phase engine at first sample `stream·W` (stream =
+    # 0..K-1), so the largest per-lane initial chip index is `K·W - 1`. `_init_state`'s
+    # single-conditional-subtract reduction only holds when that index is `< L`; beyond it
+    # the phase under-reduces and `_window_lookup` reads past the code. AVX-512 (its own
+    # builder above) carries an Int base reduced by `_wrapL` and is immune. (Off the hot path:
+    # this runs once per engine build.)
+    K * W ≤ L || throw(ArgumentError(
+        "code_engine(…, Val(K)): K·W = $(K * W) exceeds code length L = $L (W = $W lanes for " *
+        "$(backend_name(backend))); code_state(eng, K-1) would seed a chip index ≥ L. Use K ≤ $(L ÷ W)."))
     prepared = prepare_code(table; backend = backend)
     CodeEnginePhase{W,T,typeof(prepared)}(prepared, sn, sd, ph, rem0, _RemT(sd),
         _RemT(mod(stride * sn, sd)), T(div(stride * sn, sd) % L), L)

--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -129,7 +129,9 @@ end
 # Phase type `T` is Int16 for tables that fit (fast), Int32 for longer ones (the AVX2
 # path can't use the scalar-base rel trick — it regressed — so it widens the phase vector
 # instead). AVX-512 uses the rel/scalar-base path (`_init_rel`) and ignores this.
-@inline _phase_type(L) = L <= typemax(Int16) ? Int16 : Int32
+# `_advance_phase` forms `phase + whole (+1)` in T BEFORE the `≥ Lc` wrap, so T must hold
+# up to `2L-1` (phase ≤ L-1, whole_stride ≤ L-1) — hence Int16 only up to L = 16384.
+@inline _phase_type(L) = 2L - 1 <= typemax(Int16) ? Int16 : Int32
 # Fixed-point init: chip index = `p >> _B`, remainder = `p & (step_den-1)`, p = step_num·sample.
 # AVX2 has no 64-bit SIMD multiply and `p` (< 2^37 at _B=30) overflows Int32, so SPLIT
 # `step_num = hi·2^H + lo` (H = _B÷2 = 15): the partial products `hi·s` and `lo·s` both fit

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -408,6 +408,60 @@ const _BACKENDS = (CL.Portable(),
         @test CL._check_windowed_length(CL.CodeTable(ones(Int8, 8)), CL.Neon())
     end
 
+    # ── unvalidated K in code_engine(…, Val(K)) (issue #128) ──────────────────────────────
+    # `code_state(eng, stream)` seeds the phase engine's per-stream DDA at first sample
+    # `stream·W`. `_init_state`'s else-branch reduces the initial chip index with a single
+    # conditional subtract (`idx < 2L`), assuming that index is `< L` — true for the fill
+    # callers (`start_sample < 4W`) but NOT for `code_state`, which passes an unbounded
+    # `stream·W`. Once `stream·W ≥ L` (needs `K·W > L`) the index under-reduces and
+    # `_window_lookup` reads past the code, silently returning wrong / out-of-bounds chips.
+    # AVX-512 is immune (`CodeState512` carries an Int base reduced by `_wrapL`).
+    @testset "issue #128: K·W ≤ L validated in code_engine(…, Val(K))" begin
+        L = 1023
+        chips = rand(MersenneTwister(128), Int8[-1, 1], L); ct = CL.CodeTable(chips)
+        # cps = 1 (sn = sd) is the worst case: chip index = sample index, so lane j of stream
+        # k sits at chip k·W + j — the tight case the `K·W ≤ L` bound exists to guard.
+        refchip(n) = chips[mod(n + (L - 1), L) + 1]     # phase offset L-1, cps = 1
+        # Validation happens at engine construction, before any SIMD lookup, so the K·W > L
+        # rejection is checked on every phase backend (safe to *build* a NEON engine on x86);
+        # the correctness half calls `code_lookup`, so it runs only on host-runnable backends.
+        for be in (CL.Portable(), CL.AVX2(), CL.Neon())
+            W = _width(be)
+            # K·W > L: rejected at construction with a descriptive error (was: silent
+            # wrong / OOB chips from `code_state`/`code_lookup`).
+            Kbad = (L ÷ W) + 1
+            @test Kbad * W > L
+            @test_throws ArgumentError CL.code_engine(ct, _SD, _SD, Val(Kbad); phase = L - 1, backend = be)
+        end
+        # K·W ≤ L: builds, and every stream matches the per-lane fixed-point reference.
+        for be in _BACKENDS
+            be isa CL.AVX512 && continue    # immune / different engine; large K stays valid below
+            W = _width(be)
+            Kok = L ÷ W
+            eng = CL.code_engine(ct, _SD, _SD, Val(Kok); phase = L - 1, backend = be)
+            for stream in (0, Kok - 1)
+                v = CL.code_lookup(eng, CL.code_state(eng, stream))
+                @test [v[j] for j in 1:W] == [refchip(stream * W + (j - 1)) for j in 1:W]
+            end
+        end
+        # AVX-512 (W=64) is immune (Int base + `_wrapL`) and must NOT be rejected for large K.
+        if _hasfeat(:avx512vbmi)
+            @test CL.code_engine(ct, _SD, _SD, Val(64); backend = CL.AVX512()) isa CL.CodeEngine512
+        end
+    end
+
+    # ── Int16 phase-lane headroom (issue #128) ────────────────────────────────────────────
+    # `_advance_phase` adds `phase + whole (+1)` in the lane type T BEFORE the `≥ Lc` wrap, so
+    # T must hold up to `2L-1` (phase ≤ L-1, whole_stride ≤ L-1). Int16 tops out at 32767, so
+    # the widest Int16-safe length is L = 16384 (2·16384-1 = 32767); L ≥ 16385 needs Int32.
+    @testset "issue #128: _phase_type reserves Int16 headroom for _advance_phase" begin
+        @test CL._phase_type(16384) == Int16
+        @test CL._phase_type(16385) == Int32
+        @test CL._phase_type(typemax(Int16)) == Int32
+        # Largest Int16-classed built-in primary (GPS L1C data, L = 20460) now widens to Int32.
+        @test CL._phase_type(20460) == Int32
+    end
+
     # ── secondary-code period-walk overflow (issues #102 / #108) ──────────────────────────
     # `_apply_secondary!` walks whole primary periods, negating the samples of periods whose
     # residual (non-baked) secondary chip is −1. It used to compute the seed `n0·sn` and the


### PR DESCRIPTION
## Summary
Hardening for **issue #128**: nothing validated `K` in the public `code_engine(…, Val(K))` phase-engine path, so it silently accepted inputs that corrupt output. No realistic caller hits either case, but the API shouldn't accept them.

Two independent problems, both in the AVX2/NEON/Portable **phase** engine (AVX-512 uses an `Int` base reduced by `_wrapL` and is immune):

1. **Unbounded per-stream init.** `code_state(eng, stream)` seeds `_init_state` at first sample `stream·W`. The else-branch reduction is a single conditional subtract (`idx < 2L`) that assumes the initial chip index is `< L`. True for the fill callers (`start_sample < 4W`), but `code_state` passes an unbounded `stream·W`; once `stream·W ≥ L` (needs `K·W > L`) the phase under-reduces and `_window_lookup` reads past the code → silently wrong / OOB chips.
   **Fix (chosen approach: validation):** reject `K·W > L` at engine construction with a descriptive error. It runs once per build, off the hot path; the AVX-512 builder is untouched so its large-`K` use stays valid.

2. **Int16 phase-lane overflow.** `_advance_phase` forms `phase + whole (+1)` in the lane type `T` *before* the `≥ Lc` wrap, so `T` must hold `2L-1`. `_phase_type` gave Int16 up to `typemax(Int16)` with no headroom (overflow for `L ∈ [16385, 32767]` with a large `whole_stride`, e.g. GPS L1C data `L=20460`).
   **Fix:** `_phase_type(L) = 2L-1 ≤ typemax(Int16) ? Int16 : Int32` (Int16 only for `L ≤ 16384`).

## Why validation over lane-aware `_init_state`
The issue permits either. Validation is a clear, one-line guard with a descriptive error that keeps the hot path and the normal `K∈{1,4}` fast path byte-identical; a per-lane `mod` in `_init_state` would add work to code shared with the fill path for a case no real caller needs.

## Failing-test-first evidence
Before the fix:
- K·W > L: `code_engine` threw **no exception** on all three phase backends (Portable/AVX2/NEON) — silently built a corrupting engine. A direct repro (AVX2, L=1023, cps=1, phase L-1) returned chips that mismatched a per-lane fixed-point reference for `stream ≥ 33`.
- `_phase_type(16385)` and `_phase_type(20460)` returned `Int16` (asserts wanted `Int32`); `_phase_type(16384)` correctly `Int16`.

After the fix both testsets pass; the `K·W ≤ L` boundary is verified byte-exact against the per-lane reference on every host-runnable backend.

## Test results
Full suite green (`Pkg.test()`, exit 0): **CodeLUT 10035 pass**, `code_engine (value-based)` 40 pass (K=1 and K=4 fast path unchanged), Aqua clean, no regressions.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)