### PR TITLE
fix(code_lut): dense-target fallback in permute fill_continue! (strided Int8 views)

### DIFF
--- a/src/code_lut/generator.jl
+++ b/src/code_lut/generator.jl
@@ -88,6 +88,10 @@ function fill_continue!(out::AbstractVector{<:Integer}, eng::FillEngine512, st::
     padded = eng.padded; L = eng.L
     frac_W = eng.frac_W; whole_W = eng.whole_W; modulus = eng.modulus
     fstr = eng.frac_stride; wstr = eng.whole_stride
+    # Strided / non-contiguous target: the `out[VecRange]` stores below are only defined for a
+    # contiguous target (SIMD.jl), so a strided `SubArray` throws. Mirror the boundary engine's
+    # guard (#103) and walk it with the plain indexed per-sample DDA instead (issue #124).
+    _is_dense_target(out) || return _fill_continue_scalar_512!(out, eng, st)
     # Spawn the four interleaved streams (W apart) from the carried stream-0.
     rel1 = st.rel; rem1 = st.rem; b1 = st.base
     rel2, rem2, b2 = _advance_window_512(rel1, rem1, b1, frac_W, whole_W, modulus, L)
@@ -134,6 +138,22 @@ function fill_continue!(out::AbstractVector{<:Integer}, eng::FillEngine512, st::
     end
     # stream-0 is now at absolute offset num (after both the bulk and leftover advances).
     return CodeState512(rel1, rem1, b1)
+end
+
+# Non-dense fallback for `fill_continue!` (strided / non-contiguous `out`): a plain indexed
+# per-sample DDA walk over the carried stream-0 state, byte-identical to the SIMD path (just
+# slower). The stream-0 `rel[1]` is invariantly 0 (the base lane), so the current chip index is
+# just `base`; advancing every lane by one sample keeps that invariant and returns the state
+# advanced by exactly `length(out)` (issue #124).
+@inline function _fill_continue_scalar_512!(out, eng::FillEngine512, st::CodeState512)
+    padded = eng.padded; L = eng.L; modulus = eng.modulus
+    frac1 = _RemT(eng.step_num % eng.step_den); whole1 = eng.step_num ÷ eng.step_den
+    rel = st.rel; rem = st.rem; base = st.base
+    @inbounds for j in eachindex(out)
+        out[j] = padded[base + 1]
+        rel, rem, base = _advance_window_512(rel, rem, base, frac1, whole1, modulus, L)
+    end
+    return CodeState512(rel, rem, base)
 end
 
 # Advance one stream by nwin full W-windows + ntail (< W) scalar samples.
@@ -211,6 +231,11 @@ end
 function fill_continue!(out::AbstractVector{<:Integer}, eng::FillEnginePhase{W,T}, st::CodeStatePhase{W,T}) where {W,T}
     p = eng.prepared; whole_W = eng.whole_W; frac_W = eng.frac_W; modulus = eng.modulus; Lc = eng.code_length
     phase = st.phase; rem = st.rem
+    # Strided / non-contiguous target: the `out[VecRange]` stores below are only defined for a
+    # contiguous target (SIMD.jl), so a strided `SubArray` throws — even at W = 1 (Portable's
+    # `VecRange{1}`). Mirror the boundary engine's guard (#103) and walk it with the plain
+    # indexed per-sample DDA instead (issue #124).
+    _is_dense_target(out) || return _fill_continue_scalar_phase!(out, eng, st)
     num = length(out)
     nwin = num ÷ W; ntail = num - nwin * W
     pos = 0
@@ -226,6 +251,22 @@ function fill_continue!(out::AbstractVector{<:Integer}, eng::FillEnginePhase{W,T
         end
         phase, rem = _advance_scalar_phase(phase, rem, ntail, eng.step_num, eng.step_den, modulus, Lc)
         pos += ntail
+    end
+    return CodeStatePhase{W,T}(phase, rem)
+end
+
+# Non-dense fallback for the phase-engine `fill_continue!` (strided / non-contiguous `out`): a
+# plain indexed per-sample DDA walk. Lane 0 of the carried phase is the current sample's chip
+# index, and advancing every lane by one sample keeps that invariant, so `padded[phase[1]+1]`
+# reproduces the windowed lookup byte-for-byte (just slower) and the returned state is advanced
+# by exactly `length(out)` (issue #124).
+@inline function _fill_continue_scalar_phase!(out, eng::FillEnginePhase{W,T}, st::CodeStatePhase{W,T}) where {W,T}
+    padded = eng.prepared.padded; modulus = eng.modulus; Lc = eng.code_length
+    frac1 = _RemT(eng.step_num % eng.step_den); whole1 = T(eng.step_num ÷ eng.step_den)
+    phase = st.phase; rem = st.rem
+    @inbounds for j in eachindex(out)
+        out[j] = padded[Int(phase[1]) + 1]
+        phase, rem = _advance_phase(phase, rem, frac1, whole1, modulus, Lc)
     end
     return CodeStatePhase{W,T}(phase, rem)
 end

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -1183,3 +1183,57 @@ end
         @test all(==(0), @view A[:, 2])
     end
 end
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Strided targets on the *continuing permute* engines (issue #124). #103 gave the one-shot
+# permute path (kernel.jl) and the boundary `fill_continue!` a `_is_dense_target` guard, but
+# the two permute `fill_continue!` methods — `FillEngine512` (AVX-512) and `FillEnginePhase`
+# (AVX2/NEON/Portable) — still stored through `out[VecRange]`, which SIMD.jl defines only for a
+# contiguous target: a strided `SubArray` threw. Both must route non-dense targets through the
+# plain indexed fallback, byte-identically to the dense path and without clobbering neighbours.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "strided Int8 view targets on continuing permute engines (issue #124)" begin
+    chips = rand(MersenneTwister(124), Int8[-1, 1], 1023); ct = CL.CodeTable(chips)
+    N = 4000
+    for be in _BACKENDS
+        # cps in each backend's *permute* regime (m = 2^_B ÷ step_num below the boundary
+        # threshold): m = 1 (cps = 2/3) is permute for every backend; m = 2 (cps = 0.4) stays
+        # permute on AVX2/NEON (min_m = 3) and AVX-512 (min_m = 10) but hits the boundary on
+        # Portable (min_m = 2) — the `FillEngineBoundary` `continue` skips that already-fixed case.
+        for cps in (2 / 3, 0.4)
+            sn = _step_num(cps)
+            eng = CL.make_fill_engine(ct, cps; backend = be)
+            eng isa CL.FillEngineBoundary && continue   # only permute engines are under test here
+            ref = _ref(chips, sn, 0, N)
+
+            # single strided fill: must not throw, must match the dense oracle, must not clobber
+            A = zeros(Int8, 2, N); v = view(A, 1, :)     # stride 2, NOT a FastContiguousSubArray
+            CL.fill_continue!(v, eng, CL.fill_state(eng))
+            @test collect(v) == ref
+            @test all(==(0), @view A[2, :])
+
+            # chunked continuation into successive strided sub-views stays exact across boundaries
+            B = zeros(Int8, 2, N); st = CL.fill_state(eng); pos = 0
+            for chunk in (1, 777, 1024, 64, N - 1 - 777 - 1024 - 64)
+                st = CL.fill_continue!(view(B, 1, (pos + 1):(pos + chunk)), eng, st)
+                pos += chunk
+            end
+            @test collect(@view B[1, :]) == ref
+            @test all(==(0), @view B[2, :])
+        end
+    end
+end
+
+# Issue #124 reproduction at the public `code_engine` / `gen_code!` level: a permute engine
+# (1.5 MHz over GPS L1CA's 1.023 MHz → m = 1, below every backend's boundary threshold, so a
+# permute engine on any host incl. Portable) filling a strided matrix-row view must match the
+# dense fill and leave the neighbouring row intact.
+@testset "continuing permute gen_code! into a matrix row (issue #124)" begin
+    signal = GPSL1CA(); fs = 1.5MHz; N = 4000
+    ref = gen_code(N, signal, 1, fs)
+    eng = code_engine(signal, 1, fs)
+    A = zeros(Int8, 2, N); v = view(A, 1, :)
+    gen_code!(v, eng, code_state(eng))
+    @test collect(v) == ref
+    @test all(==(0), @view A[2, :])
+end


### PR DESCRIPTION
## Issue #124 — Continuing `gen_code!` permute engines crash on strided Int8 views

The continuing `gen_code!(out, eng::CodeFillEngine, st)` crashed on a non-contiguous `AbstractVector{Int8}` (e.g. a matrix row view) because the two **permute** fill engines stored through `out[VecRange{W}(…)]` with no `_is_dense_target` fallback:

- `FillEngine512.fill_continue!` (AVX-512) — `src/code_lut/generator.jl`
- `FillEnginePhase.fill_continue!` (AVX2 / NEON / **Portable**, `VecRange{1}`) — `src/code_lut/generator.jl`

SIMD.jl only defines a `VecRange` store for a `ContiguousArray`, so a strided `SubArray` threw `ArgumentError: invalid index: SIMD.VecRange`.

```julia
eng = code_engine(GPSL1CA(), 1, 1.5u"MHz")   # permute engine (m = 1)
st  = code_state(eng)
gen_code!(view(zeros(Int8, 2, 400), 1, :), eng, st)   # threw before this fix
```

This was the **residual gap of #103**: that fix gave the one-shot permute path (`kernel.jl`) and the boundary `fill_continue!` a `_is_dense_target` guard, but left the two continuing permute engines unguarded. The same call already succeeded via one-shot `gen_code!` and via the boundary engine (high oversampling).

## Fix

Mirror the boundary engine's guard in **both** permute `fill_continue!` methods: `_is_dense_target(out)` keeps the SIMD `VecRange` fast path; a non-dense target routes through a new plain indexed per-sample DDA walk (`_fill_continue_scalar_512!` / `_fill_continue_scalar_phase!`). The scalar walk is byte-identical to the SIMD path (same padded table, same DDA) and returns the state advanced by exactly `length(out)`, so chunked continuation stays seamless. The dense hot path is untouched.

## Tests

Added to `test/code_lut.jl`:
- **`strided … continuing permute engines (#124)`** — for every host backend, builds a permute-regime engine (`m < boundary threshold`), fills a strided matrix-row view, and asserts (a) no throw, (b) byte-match vs the dense scalar oracle, (c) the neighbouring row is untouched, incl. uneven chunked continuation.
- **`continuing permute gen_code! into a matrix row (#124)`** — the issue reproduction at the public `code_engine` / `gen_code!` level (1.5 MHz over GPS L1CA → `m = 1`, a permute engine on every host incl. Portable).

Confirmed **failing-test-first**: on the unfixed code the new testset errors with `ArgumentError: invalid index: SIMD.VecRange{1}` at `generator.jl:218` (Portable path). After the fix the full suite passes (Aqua + `CodeLUT` 10020 assertions + the new #124 sets), no regressions.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)