### PR TITLE
fix(code_lut): widen _make_engine value-engine strides to Int64 (32-bit)

### DIFF
--- a/src/code_lut/iterate.jl
+++ b/src/code_lut/iterate.jl
@@ -130,15 +130,21 @@ end
 
 function _make_engine(table::CodeTable, sn, sd, ph, rem0::_RemT, ::Val{K}, ::AVX512, ::Val{64}) where {K}
     W = 64; stride = K * W
+    # Widen the stride·step_num product to Int64: with step_num up to 2^_B = 2^30 it exceeds
+    # typemax(Int32), so a native-`Int` product overflows on 32-bit Julia (issue #125; residual
+    # gap of #108). Match generator.jl / the fill engines, which already form this in Int64.
+    SSN = Int64(stride) * Int64(sn); sdw = Int64(sd)
     CodeEngine512(table.padded, sn, sd, ph, rem0, _RemT(sd),
-        _RemT(mod(stride * sn, sd)), div(stride * sn, sd) % table.length, table.length)
+        _RemT(mod(SSN, sdw)), Int(div(SSN, sdw) % table.length), table.length)
 end
 function _make_engine(table::CodeTable, sn, sd, ph, rem0::_RemT, ::Val{K}, backend, ::Val{W}) where {K,W}
     backend isa Union{AVX2,Neon} && _check_windowed_length(table, backend)
     stride = K * W; L = table.length; T = _phase_type(L)
     prepared = prepare_code(table; backend = backend)
+    # Int64 stride·step_num (2^_B·stride overflows Int32 on 32-bit Julia — issue #125; see above).
+    SSN = Int64(stride) * Int64(sn); sdw = Int64(sd)
     CodeEnginePhase{W,T,typeof(prepared)}(prepared, sn, sd, ph, rem0, _RemT(sd),
-        _RemT(mod(stride * sn, sd)), T(div(stride * sn, sd) % L), L)
+        _RemT(mod(SSN, sdw)), T(Int(div(SSN, sdw) % L)), L)
 end
 
 """

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -535,6 +535,41 @@ const _BACKENDS = (CL.Portable(),
             @test Int(ep.whole_W) == Int(div(Int64(W) * sn2, Int64(sd2)) % L)
             @test ep.frac_W       == mod(Int64(W) * sn2, Int64(sd2))
         end
+        # Value-engine `_make_engine` per-stride delta widening (issue #125): the residual
+        # gap of #108. `_make_engine` bakes the K·W stride deltas as `div/mod(stride·sn, sd)`;
+        # with sn up to 2^_B the product `stride·sn` overflows Int32 on 32-bit Julia and must be
+        # done in Int64 (exactly as generator.jl / the fill engines). Pure construction-time
+        # arithmetic, so the stored deltas are host-independent and must equal the Int64 reference.
+        let sn2 = 1 << 29, sd2 = 2^30    # cps = 0.5 ⇒ sn = 2^29
+            table = CL.CodeTable(ones(Int8, 10230)); L = table.length
+            r0 = CL._RemT(0)
+            # AVX-512 path (W = 64): stride = 64, stride·sn = 2^35 overflows Int32.
+            let stride = 64
+                @test Int32(stride) * Int32(sn2) == 0                    # stride·sn wraps to 0 in Int32…
+                @test Int32(stride) * Int32(sn2) != Int64(stride) * Int64(sn2)
+                e = CL._make_engine(table, sn2, sd2, 0, r0, Val(1), CL.AVX512(), Val(64))
+                @test e.whole_stride == Int(div(Int64(stride) * sn2, Int64(sd2)) % L)
+                @test e.frac_stride  == mod(Int64(stride) * sn2, Int64(sd2))
+                @test e.whole_stride == 32 && e.whole_stride != 0        # pre-fix Int32 gave 0 → engine never advanced
+            end
+            # Phase path, the #125-headline case — AVX2 (W = 32), K = 1: stride = 32,
+            # stride·sn = 2^34 wraps to 0 in Int32 ⇒ frac_stride = whole_stride = 0 (dead engine).
+            let stride = 32
+                @test Int32(stride) * Int32(sn2) == 0
+                ep = CL._make_engine(table, sn2, sd2, 0, r0, Val(1), CL.AVX2(), Val(32))
+                @test Int(ep.whole_stride) == Int(div(Int64(stride) * sn2, Int64(sd2)) % L)
+                @test ep.frac_stride       == mod(Int64(stride) * sn2, Int64(sd2))
+                @test Int(ep.whole_stride) == 16
+            end
+            # Phase path with K > 1 driving the overflow (Portable ⇒ W = 1, stride = K):
+            # 4·sn = 2^31 overflows Int32; the widened product is still exact.
+            let stride = 4    # K = 4, W = 1
+                @test Int32(stride) * Int32(sn2) < 0                     # overflows Int32 to a negative index
+                ep = CL._make_engine(table, sn2, sd2, 0, r0, Val(4), CL.Portable(), Val(1))
+                @test Int(ep.whole_stride) == Int(div(Int64(stride) * sn2, Int64(sd2)) % L)
+                @test ep.frac_stride       == mod(Int64(stride) * sn2, Int64(sd2))
+            end
+        end
     end
 end
 


### PR DESCRIPTION
## Issue #125 — 32-bit Int overflow in `_make_engine` value-engine strides

`_make_engine` (src/code_lut/iterate.jl) bakes the per-stride DDA deltas as `div/mod(stride*sn, sd)` in **native `Int`**, missing the Int64 widening the #108 fix applied to the fill-engine constructors in `generator.jl`. This is the residual gap of #108: #108 widened `generator.jl` (`WSN = Int64(W)*Int64(step_num)`) but the value-engine constructor in `iterate.jl` computes the identical products unwidened.

### Failure (32-bit Julia)
With `stride = K·W` and `sn` up to `_STEP_DEN = 2^30`:
- cps = 0.5 → `sn = 2^29`; AVX2 (`W=32`, `K=1`): `stride·sn = 2^34` **wraps to 0 in Int32** → `frac_stride = 0`, `whole_stride = 0` → `code_advance` never moves, `code_lookup` returns wrong chips.
- Any `K·W·sn ≥ 2^31` corrupts the engine. 64-bit is safe. CI has no 32-bit job, so it would ship silently (like the original #108).

### Fix
Widen `stride·sn` to `Int64(stride) * Int64(sn)` before `div`/`mod` in **both** `_make_engine` methods (AVX-512 and phase), mirroring `generator.jl`'s #108 idiom. The widening is a no-op on 64-bit, so behaviour there is **byte-identical**.

### Test (failing-first)
Since 32-bit Julia can't run here, the added construction-time test (in the `#102 / #108` overflow testset) asserts:
- the native-Int32 product is wrong (`Int32(32)*Int32(2^29) == 0`, `Int32(64)*… ` / `Int32(4)*…` overflow), documenting the bug;
- the constructed engine's stored `frac_stride`/`whole_stride` equal the exact Int64 reference — covering AVX-512 (`W=64`), the headline AVX2 (`W=32`), and Portable (`K=4`) paths.

Emulating 32-bit arithmetic confirmed the pre-fix path yields `whole_stride = 0` (dead engine) where the Int64 fix gives the correct `16`/`32`.

Full suite green (incl. Aqua): 10031 passed, 0 failed.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)