### PR TITLE
refactor(code_lut): unify the entry-point oversampling-guard + phase-split preamble

### DIFF
--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -182,6 +182,28 @@ end # module CodeLUT
     (θ_int, rem0)
 end
 
+# Shared entry-point preamble for the three public LUT resample paths — the one-shot
+# `_gen_code_lut_core!`, the continuing `code_engine`, and the fused `code_engine(…, Val(K))`.
+# Applies the `fs ≥ fc·P` oversampling guard, then splits the real primary-chip `start_phase` /
+# `start_index_shift` into the integer sub-chip offset `phase_sub` (θ_int) and the fixed-point
+# fractional residual `rem0` the kernels consume at 2^-30-sub-chip precision (see
+# `_subchip_phase_split`). Unifying it keeps the guard condition and the phase-split convention
+# from drifting between the paths — a divergence would make gen_code! and code_engine anchor
+# phase differently and break their byte-for-byte equivalence (#131). `what` names the calling
+# entry in the guard error and `hint` is an optional trailing redirect; the `fs < fc·P`
+# condition itself is identical everywhere. (`_STEP_DEN` is the DDA denominator every path's
+# `_fixed_point_step` also returns, so the split matches the resampled stream's grid.)
+@inline function _lut_resample_setup(
+    mc::CodeLUT.ModulatedCode, fs::Float64, fc::Float64, start_phase, start_index_shift::Integer;
+    what::AbstractString, hint::AbstractString = "",
+)
+    P = mc.subchip_factor
+    fs < fc * P && error(
+        "$what needs sampling_frequency ≥ code_frequency·subchip_factor (=$(fc * P) Hz)$hint.",
+    )
+    _subchip_phase_split(start_phase, start_index_shift, fc, fs, P, CodeLUT._STEP_DEN)
+end
+
 # Map a GNSSSignals modulation to a CodeLUT modulation. ±1 for LOC/BOCsin/BOCcos/TMBOC; CBOC
 # bakes a multi-level Int8 integer approximation of its sqrt-power amplitudes, DERIVED from the
 # CBOC's own `boc1_power` (see `_cboc_int_amplitudes`) unless `cboc_amplitudes` is an explicit
@@ -405,14 +427,7 @@ end
     start_phase,
     start_index_shift::Integer,
 )
-    P = mc.subchip_factor
-    fs < fc * P && error(
-        "gen_code! needs sampling_frequency ≥ code_frequency·subchip_factor (=$(fc * P) Hz).",
-    )
-    # Split the real primary-chip start phase into an integer sub-chip offset (θ_int) and a
-    # fractional residual `rem0` at 2^-30-sub-chip precision (see `_subchip_phase_split`).
-    sd = CodeLUT._STEP_DEN
-    phase_sub, rem0 = _subchip_phase_split(start_phase, start_index_shift, fc, fs, P, sd)
+    phase_sub, rem0 = _lut_resample_setup(mc, fs, fc, start_phase, start_index_shift; what = "gen_code!")
     # Parameterless default_backend() const-folds to the host's concrete backend on non-AVX-512
     # builds; on an AVX-512 build it is a small Union{AVX512,AVX2,Portable} (a runtime Ref read
     # for the #104 demotion) union-split at the barrier below. The table-aware overload would
@@ -511,25 +526,20 @@ function code_engine(
     mc = _modulated_code_view(signal.lut, Int(prn))
     fc = _to_hz(code_frequency)
     fs = _to_hz(sampling_frequency)
-    P = mc.subchip_factor
-    fs < fc * P && error(
-        "code_engine needs sampling_frequency ≥ code_frequency·subchip_factor (=$(fc * P) Hz); use gen_code! with the signal directly.",
-    )
+    phase_sub, rem0 = _lut_resample_setup(mc, fs, fc, start_phase, start_index_shift;
+        what = "code_engine", hint = "; use gen_code! with the signal directly")
     # `backend` defaults to the parameterless `default_backend()` — const-folded on non-AVX-512
     # builds, else a small `Union{AVX512,AVX2,Portable}` (a runtime Ref read for the #104
     # demotion) union-split at the `_wrap_code_fill_engine` barrier; the table-aware overload's
     # length guard is dead code for GNSS codes and would additionally box the engine. It is
     # exposed so tests can force a *weaker* backend than the host (e.g. AVX2/Portable on an
     # AVX-512 runner) — forcing a backend the CPU lacks would SIGILL.
-    # Resample the baked sub-chip table at fc·P. Split the real primary-chip start phase into
-    # an integer sub-chip offset `phase_sub` (θ_int) and a fractional residual `rem0`.
-    cps = (fc * P) / fs
-    sn, sd = CodeLUT._fixed_point_step(cps)   # ← fixed-point step (one multiply + round)
-    phase_sub, rem0 = _subchip_phase_split(start_phase, start_index_shift, fc, fs, P, sd)
+    # Resample the baked sub-chip table at fc·P (fixed-point step: one multiply + round).
+    sn, sd = CodeLUT._fixed_point_step((fc * mc.subchip_factor) / fs)
     engine = CodeLUT.make_fill_engine(mc.table, sn, sd; phase = phase_sub, rem0 = rem0, backend = backend)
     # `mc.secondary` is a view into `signal.lut.secondary`; materialise it as an owning Vector
     # so the engine does not alias the (otherwise read-only) embedded matrix.
-    return _wrap_code_fill_engine(engine, collect(mc.secondary), mc.period_subchips, P, sn, sd, phase_sub, Int(rem0))
+    return _wrap_code_fill_engine(engine, collect(mc.secondary), mc.period_subchips, mc.subchip_factor, sn, sd, phase_sub, Int(rem0))
 end
 
 # Function barrier. `make_fill_engine` returns a small Union over the phase type (Int16 vs
@@ -619,21 +629,15 @@ function code_engine(signal::AbstractGNSSSignal, prn::Integer, sampling_frequenc
     mc = _modulated_code_view(signal.lut, Int(prn))
     fc = _to_hz(code_frequency)
     fs = _to_hz(sampling_frequency)
-    P = mc.subchip_factor
-    fs < fc * P && error(
-        "code_engine(…, Val(K)) needs sampling_frequency ≥ code_frequency·subchip_factor (=$(fc * P) Hz); use gen_code! / code_engine without Val(K).",
-    )
+    phase_sub, rem0 = _lut_resample_setup(mc, fs, fc, start_phase, start_index_shift;
+        what = "code_engine(…, Val(K))", hint = "; use gen_code! / code_engine without Val(K)")
     any(!=(Int8(1)), mc.secondary) && error(
         "code_engine(…, Val(K)) does not support a non-baked secondary (e.g. GPS L5I NH10); use gen_code! / code_engine without Val(K).",
     )
-    # Split the real primary-chip start phase into an integer sub-chip offset (θ_int) and a
-    # fractional residual `rem0` (see `_subchip_phase_split`).
-    sd = CodeLUT._STEP_DEN
-    phase_sub, rem0 = _subchip_phase_split(start_phase, start_index_shift, fc, fs, P, sd)
     # Resample the baked sub-chip table at fc·P. Parameterless default_backend() const-folds on
     # non-AVX-512 builds, else returns a small Union (a runtime Ref read for the #104 demotion)
     # union-split into the inferable per-backend engine; the table-aware overload would box it.
-    CodeLUT.code_engine(mc.table, (fc * P) / fs, Val(K);
+    CodeLUT.code_engine(mc.table, (fc * mc.subchip_factor) / fs, Val(K);
                         phase = phase_sub, rem0 = rem0, backend = CodeLUT.default_backend())
 end
 

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -847,6 +847,78 @@ end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Issue #131: the oversampling guard (`fs ≥ fc·P`) and the fractional-phase split preamble are
+# shared by all THREE public LUT entry points — the one-shot `gen_code!(out, signal, prn, …)`,
+# the continuing `code_engine(signal, prn, fs, fc)`, and the fused `code_engine(…, Val(K))`.
+# This pins that they anchor phase identically: across a rate + fractional `start_phase` /
+# `start_index_shift` sweep the three must produce BYTE-IDENTICAL output, and the guard must
+# fire at exactly the same `fs < fc·P` condition on all three (a shared setup helper must not
+# let the guard or the phase-split convention drift between the paths). Baked-secondary signals
+# only, so the `Val(K)` engine (no residual-secondary support) is exercised too.
+# ─────────────────────────────────────────────────────────────────────────────
+@testset "entry-point preamble equivalence (issue #131 characterization)" begin
+    # Materialise the fused `Val(1)` value engine's fill by concatenating its W-wide lookups.
+    function collect_val(eng, N)
+        W = code_width(eng)
+        out = Vector{Int8}(undef, N); st = code_state(eng); i = 1
+        while i + W - 1 <= N
+            v = code_lookup(eng, st)
+            for j in 1:W
+                out[i + j - 1] = v[j]
+            end
+            i += W; st = code_advance(eng, st)
+        end
+        out
+    end
+
+    sigs = [GPSL1CA(), GPSL1C_D(), GalileoE1B_BOC11()]   # BPSK, BOC(1,1), BOC(1,1) — all baked
+    for signal in sigs
+        prn = 1
+        fc = get_code_frequency(signal)
+        P = signal.lut.subchip_factor
+        for fs in (fc * P, fc * P * 2.5)                 # boundary (fs == fc·P) and permute regime
+            for (sp, sis) in ((0.0, 0), (0.25, 0), (0.5, 0), (3.5, 0), (0.0, -1), (1.7, 5))
+                # size N a multiple of the fused engine's SIMD width W so `collect_val` fills exactly.
+                eng_val = code_engine(signal, prn, fs, fc, Val(1); start_phase = sp, start_index_shift = sis)
+                W = code_width(eng_val)
+                N = 40 * W
+
+                oneshot = Vector{Int8}(undef, N)
+                gen_code!(oneshot, signal, prn, fs, fc, sp, sis)
+
+                eng = code_engine(signal, prn, fs, fc; start_phase = sp, start_index_shift = sis)
+                cont = Vector{Int8}(undef, N)
+                gen_code!(cont, eng, code_state(eng))
+
+                val = collect_val(eng_val, N)
+
+                @test cont == oneshot                    # continuing engine == one-shot
+                @test val == oneshot                     # fused Val(K) engine == one-shot
+            end
+        end
+    end
+
+    # The `fs < fc·P` oversampling guard must fire at the SAME condition on all three entry
+    # points: fine at exactly fc·P, an error for any fs below it.
+    @testset "shared oversampling guard fires identically" begin
+        signal = GPSL1C_D(); prn = 1                     # BOC(1,1) → P = 2, so fc·P > fc
+        fc = get_code_frequency(signal)
+        P = signal.lut.subchip_factor
+        @test P > 1
+        ok  = fc * P                                     # exactly at the threshold — allowed
+        bad = fc * P * 0.5                               # below fc·P — must error everywhere
+        # At the threshold none of the three throw.
+        @test gen_code!(Vector{Int8}(undef, 64), signal, prn, ok, fc) isa AbstractVector
+        @test code_engine(signal, prn, ok, fc) isa GNSSSignals.CodeFillEngine
+        @test code_engine(signal, prn, ok, fc, Val(1)) !== nothing
+        # Below the threshold all three raise (the shared guard condition).
+        @test_throws ErrorException gen_code!(Vector{Int8}(undef, 64), signal, prn, bad, fc)
+        @test_throws ErrorException code_engine(signal, prn, bad, fc)
+        @test_throws ErrorException code_engine(signal, prn, bad, fc, Val(1))
+    end
+end
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Cosine-phased BOC support in the LUT path. A cosine BOC(m,1) is the sine BOC(m,1) sub-carrier
 # shifted by a quarter cycle (`GNSSSignals.get_subcarrier_code(BOCcos, φ) == get_subcarrier_code(BOCsin, φ+¼)`),
 # so its constant segments straddle the sine sub-chip grid. Baking it at `P = 4m` quarter-sub-chips


### PR DESCRIPTION
## Issue #131

The entry-point preamble — the `fs ≥ fc·P` oversampling guard plus the `_subchip_phase_split` call — was **triplicated** across the three public LUT resample entry points in `src/code_lut.jl`:

- `_gen_code_lut_core!` (one-shot `gen_code!`)
- `code_engine(signal, prn, fs, fc)` (continuing engine)
- `code_engine(…, Val(K))` (fused register-resident engine)

The guard **error strings had already drifted apart**. A future fix to the phase-split convention or the `fs ≥ fc·P` rule applied to only one copy would make the one-shot and engine paths anchor phase differently — a byte-level divergence between `gen_code!` and `code_engine` output, exactly the equivalence the test suite relies on. Same unification spirit as the resolved #110.

## Change

Extract one shared helper:

```julia
_lut_resample_setup(mc, fs, fc, start_phase, start_index_shift; what, hint) -> (phase_sub, rem0)
```

It applies the oversampling guard and returns the fractional-phase split, and is called by all three entry points. Each entry keeps its own error-message prefix/suffix via the `what`/`hint` parameters, so the guard messages are **byte-identical** to before; the `fs < fc·P` condition and the `_STEP_DEN`-based split are now single-sourced.

**Behavior-preserving**: the guard condition, phase-split math, and generated output are unchanged. The backend-selection comments at each entry point are preserved and remain accurate (only the phase-split sentence, now living in the helper, was removed from them).

## Tests

Added a #131 characterization testset pinning that:
- one-shot `gen_code!`, continuing `code_engine`, and fused `code_engine(…, Val(1))` produce **byte-identical** output across a rate + fractional `start_phase` / `start_index_shift` sweep (incl. negative shift), and
- the oversampling guard fires at the **identical** `fs < fc·P` condition on all three entry points.

It passes both before and after the refactor (no bug-style failing test — this guards against future drift). Full suite (incl. Aqua) passes locally.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)