### PR TITLE
feat: expose signal constants at the type level + TimeSystem abstraction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "3.0.0"
 authors = ["Soeren Schoenbrod <soeren.schoenbrod@nav.rwth-aachen.de>", "Michael Niestroj <michael.niestroj@nav.rwth-aachen.de"]
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
@@ -12,6 +13,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Aqua = "0.8"
+Dates = "1"
 DocStringExtensions = "0.6, 0.7, 0.8, 0.9"
 FixedPointNumbers = "0.8, 0.9"
 SIMD = "3"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -29,6 +29,17 @@ GNSSSignals.L5
 GNSSSignals.get_band
 ```
 
+## Time Systems
+
+```@docs
+GNSSSignals.TimeSystem
+GNSSSignals.GPST
+GNSSSignals.GST
+GNSSSignals.get_time_system
+GNSSSignals.get_system_start_time
+GNSSSignals.get_tai_offset
+```
+
 ## Secondary Codes
 
 ```@docs

--- a/src/GNSSSignals.jl
+++ b/src/GNSSSignals.jl
@@ -1,10 +1,11 @@
 module GNSSSignals
 
+using Dates: DateTime
 using DocStringExtensions
 using FixedPointNumbers
 using SIMD: Vec, vload, vstore, vifelse, shufflevector
 using Statistics
-using Unitful: Frequency, Hz, upreferred, ustrip, @u_str
+using Unitful: Frequency, Hz, s, upreferred, ustrip, @u_str
 
 import Base.show
 
@@ -47,6 +48,12 @@ export AbstractGNSSSignal,
     get_code_spectrum,
     get_band,
     get_signal_name,
+    TimeSystem,
+    GPST,
+    GST,
+    get_time_system,
+    get_system_start_time,
+    get_tai_offset,
     min_bits_for_code_length,
     get_modulation,
     get_secondary_code,
@@ -148,6 +155,7 @@ include("gps/l2c.jl")
 include("galileo/e1b.jl")
 include("galileo/e1c.jl")
 include("galileo/e5a.jl")
+include("time_systems.jl")
 include("common.jl")
 include("code_lut.jl")
 end

--- a/src/bands.jl
+++ b/src/bands.jl
@@ -60,13 +60,20 @@ $(SIGNATURES)
 Get the center (carrier) frequency of a signal.
 
 Dispatches through the signal's band ([`get_band`](@ref)), so all signals on
-the same band return the same value by construction.
+the same band return the same value by construction. Works on either a signal
+instance or its type — `get_center_frequency(GPSL1CA)` avoids constructing a
+signal just to read the carrier.
 
 ```julia-repl
 julia> get_center_frequency(GPSL1CA())
 1575420000 Hz
+
+julia> get_center_frequency(GPSL1CA)
+1575420000 Hz
 ```
 """
+@inline get_center_frequency(::Type{S}) where {S<:AbstractGNSSSignal} =
+    get_center_frequency(get_band(S))
 @inline get_center_frequency(s::AbstractGNSSSignal) = get_center_frequency(get_band(s))
 
 """
@@ -74,6 +81,10 @@ $(SIGNATURES)
 
 Get the [`Band`](@ref) a signal is transmitted on.
 
-Concrete signal types define one method each, e.g. `get_band(::GPSL1CA) = L1()`.
+Concrete signal types define one method each on the type, e.g.
+`get_band(::Type{<:GPSL1CA}) = L1()`, so the band is available without
+constructing a signal. The instance method forwards to the type.
 """
 function get_band end
+
+@inline get_band(s::AbstractGNSSSignal) = get_band(typeof(s))

--- a/src/common.jl
+++ b/src/common.jl
@@ -54,6 +54,12 @@ to such platforms.
 """
 widen_codes_to_storage(codes::AbstractMatrix) = Int16.(codes)
 
+# Each concrete signal defines these on `::Type{<:Signal}` (per-signal files);
+# these forward an instance to its type.
+@inline get_code_length(s::AbstractGNSSSignal) = get_code_length(typeof(s))
+@inline get_code_frequency(s::AbstractGNSSSignal) = get_code_frequency(typeof(s))
+@inline get_data_frequency(s::AbstractGNSSSignal) = get_data_frequency(typeof(s))
+
 # NOTE: the legacy fixed-point `gen_code!` and its `sample_code!` / `dispatch_sample_code_worker!`
 # / `sample_code_worker!` / `sample_code_worker_generic!` / `sample_code_tail!` /
 # `_pad_inner_iterations` machinery (plus the `SAMPLE_CODE_INNER_THRESHOLD` / `HAS_AVX512`

--- a/src/galileo/e1b.jl
+++ b/src/galileo/e1b.jl
@@ -36,7 +36,7 @@ julia> get_band(GalileoE1B())
 L1()
 ```
 """
-@inline get_band(::GalileoE1B) = L1()
+@inline get_band(::Type{<:GalileoE1B}) = L1()
 
 """
 $(SIGNATURES)
@@ -87,7 +87,7 @@ julia> get_code_length(GalileoE1B())
 4092
 ```
 """
-@inline function get_code_length(::GalileoE1B)
+@inline function get_code_length(::Type{<:GalileoE1B})
     4092
 end
 
@@ -126,7 +126,7 @@ julia> get_code_frequency(GalileoE1B())
 1023000 Hz
 ```
 """
-@inline function get_code_frequency(::GalileoE1B)
+@inline function get_code_frequency(::Type{<:GalileoE1B})
     1023_000Hz
 end
 
@@ -144,7 +144,7 @@ julia> get_data_frequency(GalileoE1B())
 250 Hz
 ```
 """
-@inline function get_data_frequency(::GalileoE1B)
+@inline function get_data_frequency(::Type{<:GalileoE1B})
     250Hz
 end
 
@@ -186,7 +186,7 @@ end
 get_modulation(::Type{<:GalileoE1B_BOC11}) = BOCsin(1, 1)
 @inline get_modulation(::GalileoE1B_BOC11) = BOCsin(1, 1)
 
-@inline get_band(::GalileoE1B_BOC11) = L1()
+@inline get_band(::Type{<:GalileoE1B_BOC11}) = L1()
 get_signal_name(::GalileoE1B_BOC11) = "Galileo E1B (BOC(1,1) approximation)"
 
 function GalileoE1B_BOC11()
@@ -195,7 +195,7 @@ function GalileoE1B_BOC11()
     GalileoE1B_BOC11(codes, lut)
 end
 
-@inline get_code_length(::GalileoE1B_BOC11) = 4092
+@inline get_code_length(::Type{<:GalileoE1B_BOC11}) = 4092
 @inline get_secondary_code(::GalileoE1B_BOC11) = NoSecondaryCode()
-@inline get_code_frequency(::GalileoE1B_BOC11) = 1023_000Hz
-@inline get_data_frequency(::GalileoE1B_BOC11) = 250Hz
+@inline get_code_frequency(::Type{<:GalileoE1B_BOC11}) = 1023_000Hz
+@inline get_data_frequency(::Type{<:GalileoE1B_BOC11}) = 250Hz

--- a/src/galileo/e1c.jl
+++ b/src/galileo/e1c.jl
@@ -47,7 +47,7 @@ julia> get_band(GalileoE1C())
 L1()
 ```
 """
-@inline get_band(::GalileoE1C) = L1()
+@inline get_band(::Type{<:GalileoE1C}) = L1()
 
 """
 $(SIGNATURES)
@@ -91,7 +91,7 @@ julia> get_code_length(GalileoE1C())
 4092
 ```
 """
-@inline function get_code_length(::GalileoE1C)
+@inline function get_code_length(::Type{<:GalileoE1C})
     4092
 end
 
@@ -143,7 +143,7 @@ julia> get_code_frequency(GalileoE1C())
 1023000 Hz
 ```
 """
-@inline function get_code_frequency(::GalileoE1C)
+@inline function get_code_frequency(::Type{<:GalileoE1C})
     1023_000Hz
 end
 
@@ -163,7 +163,7 @@ julia> get_data_frequency(GalileoE1C())
 0 Hz
 ```
 """
-@inline function get_data_frequency(::GalileoE1C)
+@inline function get_data_frequency(::Type{<:GalileoE1C})
     0Hz
 end
 
@@ -206,7 +206,7 @@ end
 get_modulation(::Type{<:GalileoE1C_BOC11}) = BOCsin(1, 1)
 @inline get_modulation(::GalileoE1C_BOC11) = BOCsin(1, 1)
 
-@inline get_band(::GalileoE1C_BOC11) = L1()
+@inline get_band(::Type{<:GalileoE1C_BOC11}) = L1()
 get_signal_name(::GalileoE1C_BOC11) = "Galileo E1C (BOC(1,1) approximation)"
 
 function GalileoE1C_BOC11()
@@ -215,7 +215,7 @@ function GalileoE1C_BOC11()
     GalileoE1C_BOC11(codes, lut)
 end
 
-@inline get_code_length(::GalileoE1C_BOC11) = 4092
+@inline get_code_length(::Type{<:GalileoE1C_BOC11}) = 4092
 @inline get_secondary_code(::GalileoE1C_BOC11) = galileo_e1c_secondary_code()
-@inline get_code_frequency(::GalileoE1C_BOC11) = 1023_000Hz
-@inline get_data_frequency(::GalileoE1C_BOC11) = 0Hz
+@inline get_code_frequency(::Type{<:GalileoE1C_BOC11}) = 1023_000Hz
+@inline get_data_frequency(::Type{<:GalileoE1C_BOC11}) = 0Hz

--- a/src/galileo/e5a.jl
+++ b/src/galileo/e5a.jl
@@ -251,8 +251,8 @@ julia> get_band(GalileoE5aI())
 L5()
 ```
 """
-@inline get_band(::GalileoE5aI) = L5()
-@inline get_band(::GalileoE5aQ) = L5()
+@inline get_band(::Type{<:GalileoE5aI}) = L5()
+@inline get_band(::Type{<:GalileoE5aQ}) = L5()
 
 """
 $(SIGNATURES)
@@ -273,16 +273,16 @@ $(SIGNATURES)
 
 Get the code length for Galileo E5a (10230 chips, both components).
 """
-@inline get_code_length(::GalileoE5aI) = 10230
-@inline get_code_length(::GalileoE5aQ) = 10230
+@inline get_code_length(::Type{<:GalileoE5aI}) = 10230
+@inline get_code_length(::Type{<:GalileoE5aQ}) = 10230
 
 """
 $(SIGNATURES)
 
 Get the code chipping rate for Galileo E5a (10.23 MHz, both components).
 """
-@inline get_code_frequency(::GalileoE5aI) = 10_230_000Hz
-@inline get_code_frequency(::GalileoE5aQ) = 10_230_000Hz
+@inline get_code_frequency(::Type{<:GalileoE5aI}) = 10_230_000Hz
+@inline get_code_frequency(::Type{<:GalileoE5aQ}) = 10_230_000Hz
 
 """
 $(SIGNATURES)
@@ -295,7 +295,7 @@ symbols/s rate (25 bps with rate-1/2 convolutional coding).
 # Returns
 - `Frequency`: 50 Hz
 """
-@inline get_data_frequency(::GalileoE5aI) = 50Hz
+@inline get_data_frequency(::Type{<:GalileoE5aI}) = 50Hz
 
 """
 $(SIGNATURES)
@@ -307,7 +307,7 @@ The E5a-Q component is a dataless pilot.
 # Returns
 - `Frequency`: 0 Hz
 """
-@inline get_data_frequency(::GalileoE5aQ) = 0Hz
+@inline get_data_frequency(::Type{<:GalileoE5aQ}) = 0Hz
 
 """
 $(SIGNATURES)

--- a/src/gps/l1c_d.jl
+++ b/src/gps/l1c_d.jl
@@ -35,7 +35,7 @@ $(SIGNATURES)
 
 Get the band the signal is transmitted on.
 """
-@inline get_band(::GPSL1C_D) = L1()
+@inline get_band(::Type{<:GPSL1C_D}) = L1()
 
 """
 $(SIGNATURES)
@@ -62,7 +62,7 @@ Get the primary code length for GPS L1C-D.
 # Returns
 - `Int`: 10230 chips
 """
-@inline get_code_length(::GPSL1C_D) = L1C_PRIMARY_LENGTH
+@inline get_code_length(::Type{<:GPSL1C_D}) = L1C_PRIMARY_LENGTH
 
 """
 $(SIGNATURES)
@@ -82,7 +82,7 @@ Get the code chipping rate for GPS L1C-D.
 # Returns
 - `Frequency`: 1.023 MHz
 """
-@inline get_code_frequency(::GPSL1C_D) = 1_023_000Hz
+@inline get_code_frequency(::Type{<:GPSL1C_D}) = 1_023_000Hz
 
 """
 $(SIGNATURES)
@@ -99,4 +99,4 @@ post-FEC channel symbol rate, not the pre-FEC information rate.
 # Returns
 - `Frequency`: 100 Hz
 """
-@inline get_data_frequency(::GPSL1C_D) = 100Hz
+@inline get_data_frequency(::Type{<:GPSL1C_D}) = 100Hz

--- a/src/gps/l1c_p.jl
+++ b/src/gps/l1c_p.jl
@@ -37,7 +37,7 @@ $(SIGNATURES)
 
 Get the band the signal is transmitted on.
 """
-@inline get_band(::GPSL1C_P) = L1()
+@inline get_band(::Type{<:GPSL1C_P}) = L1()
 
 """
 $(SIGNATURES)
@@ -67,7 +67,7 @@ Get the primary code length for GPS L1C-P.
 # Returns
 - `Int`: 10230 chips
 """
-@inline get_code_length(::GPSL1C_P) = L1C_PRIMARY_LENGTH
+@inline get_code_length(::Type{<:GPSL1C_P}) = L1C_PRIMARY_LENGTH
 
 """
 $(SIGNATURES)
@@ -91,7 +91,7 @@ Get the code chipping rate for GPS L1C-P.
 # Returns
 - `Frequency`: 1.023 MHz
 """
-@inline get_code_frequency(::GPSL1C_P) = 1_023_000Hz
+@inline get_code_frequency(::Type{<:GPSL1C_P}) = 1_023_000Hz
 
 """
 $(SIGNATURES)
@@ -103,4 +103,4 @@ The pilot component is dataless.
 # Returns
 - `Frequency`: 0 Hz
 """
-@inline get_data_frequency(::GPSL1C_P) = 0Hz
+@inline get_data_frequency(::Type{<:GPSL1C_P}) = 0Hz

--- a/src/gps/l1ca.jl
+++ b/src/gps/l1ca.jl
@@ -33,7 +33,7 @@ julia> get_band(GPSL1CA())
 L1()
 ```
 """
-@inline get_band(::GPSL1CA) = L1()
+@inline get_band(::Type{<:GPSL1CA}) = L1()
 
 """
 $(SIGNATURES)
@@ -77,7 +77,7 @@ julia> get_code_length(GPSL1CA())
 1023
 ```
 """
-@inline function get_code_length(::GPSL1CA)
+@inline function get_code_length(::Type{<:GPSL1CA})
     1023
 end
 
@@ -115,7 +115,7 @@ julia> get_code_frequency(GPSL1CA())
 1023000 Hz
 ```
 """
-@inline function get_code_frequency(::GPSL1CA)
+@inline function get_code_frequency(::Type{<:GPSL1CA})
     1_023_000Hz
 end
 
@@ -133,6 +133,6 @@ julia> get_data_frequency(GPSL1CA())
 50 Hz
 ```
 """
-@inline function get_data_frequency(::GPSL1CA)
+@inline function get_data_frequency(::Type{<:GPSL1CA})
     50Hz
 end

--- a/src/gps/l2c.jl
+++ b/src/gps/l2c.jl
@@ -146,8 +146,8 @@ julia> get_band(GPSL2CM())
 L2()
 ```
 """
-@inline get_band(::GPSL2CM) = L2()
-@inline get_band(::GPSL2CL) = L2()
+@inline get_band(::Type{<:GPSL2CM}) = L2()
+@inline get_band(::Type{<:GPSL2CL}) = L2()
 
 """
 $(SIGNATURES)
@@ -174,7 +174,7 @@ julia> get_code_length(GPSL2CM())
 10230
 ```
 """
-@inline get_code_length(::GPSL2CM) = GPS_L2CM_CODE_LENGTH
+@inline get_code_length(::Type{<:GPSL2CM}) = GPS_L2CM_CODE_LENGTH
 
 """
 $(SIGNATURES)
@@ -187,7 +187,7 @@ julia> get_code_length(GPSL2CL())
 767250
 ```
 """
-@inline get_code_length(::GPSL2CL) = GPS_L2CL_CODE_LENGTH
+@inline get_code_length(::Type{<:GPSL2CL}) = GPS_L2CL_CODE_LENGTH
 
 """
 $(SIGNATURES)
@@ -226,8 +226,8 @@ julia> get_code_frequency(GPSL2CM())
 511500 Hz
 ```
 """
-@inline get_code_frequency(::GPSL2CM) = GPS_L2C_CODE_FREQUENCY
-@inline get_code_frequency(::GPSL2CL) = GPS_L2C_CODE_FREQUENCY
+@inline get_code_frequency(::Type{<:GPSL2CM}) = GPS_L2C_CODE_FREQUENCY
+@inline get_code_frequency(::Type{<:GPSL2CL}) = GPS_L2C_CODE_FREQUENCY
 
 """
 $(SIGNATURES)
@@ -242,7 +242,7 @@ broadcast symbol rate, matching the convention used across this package (see
 # Returns
 - `Frequency`: 50 Hz
 """
-@inline get_data_frequency(::GPSL2CM) = 50Hz
+@inline get_data_frequency(::Type{<:GPSL2CM}) = 50Hz
 
 """
 $(SIGNATURES)
@@ -254,4 +254,4 @@ The L2 CL-code is a dataless pilot, so its data frequency is 0 Hz.
 # Returns
 - `Frequency`: 0 Hz
 """
-@inline get_data_frequency(::GPSL2CL) = 0Hz
+@inline get_data_frequency(::Type{<:GPSL2CL}) = 0Hz

--- a/src/gps/l5.jl
+++ b/src/gps/l5.jl
@@ -244,8 +244,8 @@ julia> get_band(GPSL5I())
 L5()
 ```
 """
-@inline get_band(::GPSL5I) = L5()
-@inline get_band(::GPSL5Q) = L5()
+@inline get_band(::Type{<:GPSL5I}) = L5()
+@inline get_band(::Type{<:GPSL5Q}) = L5()
 
 """
 $(SIGNATURES)
@@ -272,8 +272,8 @@ julia> get_code_length(GPSL5I())
 10230
 ```
 """
-@inline get_code_length(::GPSL5I) = 10230
-@inline get_code_length(::GPSL5Q) = 10230
+@inline get_code_length(::Type{<:GPSL5I}) = 10230
+@inline get_code_length(::Type{<:GPSL5Q}) = 10230
 
 """
 $(SIGNATURES)
@@ -286,8 +286,8 @@ julia> get_code_frequency(GPSL5I())
 10230000 Hz
 ```
 """
-@inline get_code_frequency(::GPSL5I) = 10_230_000Hz
-@inline get_code_frequency(::GPSL5Q) = 10_230_000Hz
+@inline get_code_frequency(::Type{<:GPSL5I}) = 10_230_000Hz
+@inline get_code_frequency(::Type{<:GPSL5Q}) = 10_230_000Hz
 
 """
 $(SIGNATURES)
@@ -308,7 +308,7 @@ julia> get_data_frequency(GPSL5I())
 100 Hz
 ```
 """
-@inline get_data_frequency(::GPSL5I) = 100Hz
+@inline get_data_frequency(::Type{<:GPSL5I}) = 100Hz
 
 """
 $(SIGNATURES)
@@ -326,7 +326,7 @@ julia> get_data_frequency(GPSL5Q())
 0 Hz
 ```
 """
-@inline get_data_frequency(::GPSL5Q) = 0Hz
+@inline get_data_frequency(::Type{<:GPSL5Q}) = 0Hz
 
 """
 $(SIGNATURES)

--- a/src/time_systems.jl
+++ b/src/time_systems.jl
@@ -1,0 +1,143 @@
+"""
+    TimeSystem
+
+Abstract supertype for a GNSS time scale.
+
+A *time system* is a continuous atomic time scale (no leap seconds) that a
+constellation references its broadcast time to: [`GPST`](@ref) for the GPS
+signals, [`GST`](@ref) for the Galileo signals. Signals that report the same
+time system share a receiver clock bias — that is the architectural reason
+this abstraction exists, mirroring [`Band`](@ref) for the RF carrier.
+
+A time scale is fixed by two constants, both queried through it:
+[`get_system_start_time`](@ref) (its epoch) and [`get_tai_offset`](@ref) (its
+offset from TAI).
+"""
+abstract type TimeSystem end
+
+"""
+    GPST <: TimeSystem
+
+GPS Time. Epoch `1980-01-06T00:00:00` UTC, `GPST = TAI − 19 s`, no leap
+seconds (IS-GPS-200). Used by every GPS signal.
+"""
+struct GPST <: TimeSystem end
+
+"""
+    GST <: TimeSystem
+
+Galileo System Time. Epoch is 13 s before midnight 21/22 August 1999, i.e.
+`1999-08-21T23:59:47` UTC; `GST = TAI − 19 s`, no leap seconds (Galileo OS SIS
+ICD, Issue 2.2, §5.1.2). Used by every Galileo signal.
+"""
+struct GST <: TimeSystem end
+
+"""
+$(SIGNATURES)
+
+Get the start epoch of a GNSS time scale, as a UTC `DateTime`.
+
+This is the instant at which the broadcast time count (week number 0, time of
+week 0) is zero. Works on a [`TimeSystem`](@ref), or on a signal / signal type
+(which forwards through [`get_time_system`](@ref)).
+
+The Galileo epoch is **not** on a UTC minute boundary: the Galileo OS SIS ICD
+(Issue 2.2, §5.1.2) defines it as 13 s before midnight between 21 and 22
+August 1999, i.e. `1999-08-21T23:59:47` UTC. The GPS epoch is
+`1980-01-06T00:00:00` UTC (IS-GPS-200).
+
+See also [`get_tai_offset`](@ref) for the time scale's constant offset from TAI.
+
+# Examples
+```julia-repl
+julia> get_system_start_time(GPST())
+1980-01-06T00:00:00
+
+julia> get_system_start_time(GalileoE1B())
+1999-08-21T23:59:47
+```
+"""
+@inline get_system_start_time(::GPST) = DateTime(1980, 1, 6, 0, 0, 0)
+@inline get_system_start_time(::GST) = DateTime(1999, 8, 21, 23, 59, 47)
+
+"""
+$(SIGNATURES)
+
+Get the constant offset between a GNSS time scale and TAI, as a Unitful time
+quantity.
+
+The value is the leap-second-free amount by which TAI leads the time scale:
+
+    TAI = system_time + get_tai_offset(time_system)
+
+equivalently `system_time = TAI − get_tai_offset(time_system)`. Works on a
+[`TimeSystem`](@ref), or on a signal / signal type (which forwards through
+[`get_time_system`](@ref)).
+
+Both currently-modelled time scales — [`GPST`](@ref) and [`GST`](@ref) — are
+defined as `TAI − 19 s`, so this returns `19s` for either. It is defined per
+time system (not as a shared fallback) so a future system with a different
+offset (e.g. BeiDou Time, `TAI − 33 s`) states its own value.
+
+# Examples
+```julia-repl
+julia> get_tai_offset(GST())
+19 s
+
+julia> get_tai_offset(GPSL1CA) == get_tai_offset(GalileoE1B)
+true
+```
+"""
+@inline get_tai_offset(::GPST) = 19s
+@inline get_tai_offset(::GST) = 19s
+
+"""
+$(SIGNATURES)
+
+Get the [`TimeSystem`](@ref) a signal's measurements are referenced to.
+
+Concrete signal types define one method each on the type, e.g.
+`get_time_system(::Type{<:GPSL1CA}) = GPST()`, so the time system is available
+without constructing a signal. The instance method forwards to the type.
+
+# Examples
+```julia-repl
+julia> get_time_system(GPSL1CA)
+GPST()
+
+julia> get_time_system(GalileoE1B())
+GST()
+```
+"""
+function get_time_system end
+
+@inline get_time_system(s::AbstractGNSSSignal) = get_time_system(typeof(s))
+
+# Signal → time system. This is the only genuinely per-signal fact here (like
+# the per-signal `get_band`); the epoch and TAI offset are properties of the
+# time system, defined once above.
+# GPS signals: GPS Time.
+@inline get_time_system(::Type{<:GPSL1CA}) = GPST()
+@inline get_time_system(::Type{<:GPSL1C_D}) = GPST()
+@inline get_time_system(::Type{<:GPSL1C_P}) = GPST()
+@inline get_time_system(::Type{<:GPSL2CM}) = GPST()
+@inline get_time_system(::Type{<:GPSL2CL}) = GPST()
+@inline get_time_system(::Type{<:GPSL5I}) = GPST()
+@inline get_time_system(::Type{<:GPSL5Q}) = GPST()
+# Galileo signals: Galileo System Time.
+@inline get_time_system(::Type{<:GalileoE1B}) = GST()
+@inline get_time_system(::Type{<:GalileoE1B_BOC11}) = GST()
+@inline get_time_system(::Type{<:GalileoE1C}) = GST()
+@inline get_time_system(::Type{<:GalileoE1C_BOC11}) = GST()
+@inline get_time_system(::Type{<:GalileoE5aI}) = GST()
+@inline get_time_system(::Type{<:GalileoE5aQ}) = GST()
+
+# Signal-level access forwards through the time system — same dual entry (type
+# or instance) as `get_center_frequency` through `get_band`.
+@inline get_system_start_time(::Type{S}) where {S<:AbstractGNSSSignal} =
+    get_system_start_time(get_time_system(S))
+@inline get_system_start_time(s::AbstractGNSSSignal) =
+    get_system_start_time(get_time_system(s))
+@inline get_tai_offset(::Type{S}) where {S<:AbstractGNSSSignal} =
+    get_tai_offset(get_time_system(S))
+@inline get_tai_offset(s::AbstractGNSSSignal) = get_tai_offset(get_time_system(s))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ if !SIMD_ONLY
 
     include("test_codes.jl")
     include("bands.jl")
+    include("time_systems.jl")
     include("modulation.jl")
     include("gps/l1ca.jl")
     include("gps/l5.jl")

--- a/test/time_systems.jl
+++ b/test/time_systems.jl
@@ -1,0 +1,51 @@
+using Dates: DateTime
+import Unitful: s
+
+@testset "Time systems" begin
+    gps_signals = (GPSL1CA, GPSL1C_D, GPSL1C_P, GPSL2CM, GPSL2CL, GPSL5I, GPSL5Q)
+    galileo_signals =
+        (GalileoE1B, GalileoE1B_BOC11, GalileoE1C, GalileoE1C_BOC11, GalileoE5aI, GalileoE5aQ)
+
+    @test GPST <: TimeSystem
+    @test GST <: TimeSystem
+
+    # Signal → time system (the only per-signal fact).
+    for S in gps_signals
+        @test @inferred(get_time_system(S)) === GPST()
+    end
+    for S in galileo_signals
+        @test @inferred(get_time_system(S)) === GST()
+    end
+    # Instance path forwards to the type.
+    @test get_time_system(GPSL1CA()) === get_time_system(GPSL1CA) === GPST()
+    @test get_time_system(GalileoE1B()) === get_time_system(GalileoE1B) === GST()
+
+    # Epoch / offset defined on the time system (IS-GPS-200 / Galileo OS SIS
+    # ICD 2.2 §5.1.2). The Galileo epoch is not a UTC minute boundary.
+    @test @inferred(get_system_start_time(GPST())) == DateTime(1980, 1, 6, 0, 0, 0)
+    @test @inferred(get_system_start_time(GST())) == DateTime(1999, 8, 21, 23, 59, 47)
+    @test @inferred(get_tai_offset(GPST())) == 19s
+    @test @inferred(get_tai_offset(GST())) == 19s
+
+    # Signal-level access forwards through the time system, on type or instance.
+    for S in gps_signals
+        @test get_system_start_time(S) == DateTime(1980, 1, 6, 0, 0, 0)
+        @test get_system_start_time(S()) == get_system_start_time(S)
+        @test get_tai_offset(S) == 19s
+    end
+    for S in galileo_signals
+        @test get_system_start_time(S) == DateTime(1999, 8, 21, 23, 59, 47)
+        @test get_system_start_time(S()) == get_system_start_time(S)
+        @test get_tai_offset(S) == 19s
+    end
+
+    # The TAI offset is identical across every implemented signal — both GPST
+    # and GST are defined as TAI − 19 s.
+    all_signals = (gps_signals..., galileo_signals...)
+    @test length(unique(get_tai_offset(S) for S in all_signals)) == 1
+
+    # GPS and Galileo share the offset but differ in epoch / time system.
+    @test get_tai_offset(GPSL1CA) == get_tai_offset(GalileoE1B)
+    @test get_system_start_time(GPSL1CA) != get_system_start_time(GalileoE1B)
+    @test get_time_system(GPSL1CA) !== get_time_system(GalileoE1B)
+end


### PR DESCRIPTION
## Summary

Two related additions, both making per-signal/per-constellation constants queryable without constructing a signal (constructing one reads the code binary off disk and builds a LUT):

1. **Type-level metadata getters.** `get_band`, `get_center_frequency`, `get_code_length`, `get_code_frequency` and `get_data_frequency` now dispatch on `::Type{<:Signal}` in addition to an instance. So `get_data_frequency(GalileoE1B)` works and costs nothing, alongside the existing `get_data_frequency(GalileoE1B())`. This mirrors how `get_modulation` already dispatches on the type.

2. **A `TimeSystem` abstraction**, modelled on the existing `Band`. GNSS time scales become first-class singleton types (`GPST`, `GST`), and the constellation-wide facts are defined once per system rather than repeated per signal:
   - `get_time_system(signal_or_type) -> GPST()/GST()`
   - `get_system_start_time(::TimeSystem) -> DateTime` (UTC epoch)
   - `get_tai_offset(::TimeSystem)` (intrinsic, leap-second-free system↔TAI offset)

   Signal-level access forwards through `get_time_system` (type or instance), the same dual entry as `get_center_frequency` through `get_band`.

## Motivation

Downstream code (e.g. PositionVelocityTime.jl) was constructing a full signal just to read a constant, and hardcoding constellation facts such as the GNSS time-scale epochs. This exposes those as the single source of truth in GNSSSignals, where they belong, and gives consumers a first-class time-system identity to group by instead of ad-hoc symbols.

## Values & sources

Both GPS Time and Galileo System Time are `TAI − 19 s` (continuous, no leap seconds); they differ only in epoch:

| Time system | Epoch (UTC) | Offset |
|---|---|---|
| `GPST` | `1980-01-06T00:00:00` | TAI − 19 s |
| `GST`  | `1999-08-21T23:59:47` | TAI − 19 s |

Sourced from IS-GPS-200 and the Galileo OS SIS ICD, Issue 2.2, §5.1.2 (which defines the GST epoch as 13 s before midnight 21/22 August 1999 — a non-UTC-minute-boundary instant). Epochs are returned dependency-free as `Dates.DateTime`; the TAI offset as a Unitful quantity — deliberately keeping AstroTime and any leap-second machinery out of GNSSSignals.

## API changes

New exports: `TimeSystem`, `GPST`, `GST`, `get_time_system`, `get_system_start_time`, `get_tai_offset`. New dependency: `Dates` (stdlib).

**Non-breaking.** Nothing is removed or renamed relative to 3.0.0; existing instance-based getter calls resolve identically through the new forwarders. This is a `feat` (minor bump).

## Testing

- New `test/time_systems.jl` covering the mapping, epoch/offset per system, signal-level forwarding (type and instance), and that the TAI offset is identical across all 13 implemented signals.
- Full suite and Aqua pass locally.
