### PR TITLE
refactor: per-constellation signal supertypes; collapse get_time_system to one method per GNSS

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -4,6 +4,8 @@
 
 ```@docs
 GNSSSignals.AbstractGNSSSignal
+GNSSSignals.AbstractGPSSignal
+GNSSSignals.AbstractGalileoSignal
 GNSSSignals.GPSL1CA
 GNSSSignals.GPSL1C_D
 GNSSSignals.GPSL1C_P

--- a/src/GNSSSignals.jl
+++ b/src/GNSSSignals.jl
@@ -10,6 +10,8 @@ using Unitful: Frequency, Hz, s, upreferred, ustrip, @u_str
 import Base.show
 
 export AbstractGNSSSignal,
+    AbstractGPSSignal,
+    AbstractGalileoSignal,
     Band,
     L1,
     L2,
@@ -80,6 +82,33 @@ Signals that share an RF carrier expose the same [`Band`](@ref) via
 between them (e.g. GPS L1 C/A and Galileo E1B both on 1575.42 MHz).
 """
 abstract type AbstractGNSSSignal{C} end
+
+"""
+    AbstractGPSSignal{C} <: AbstractGNSSSignal{C}
+
+Abstract supertype for a signal transmitted by the GPS constellation, e.g.
+[`GPSL1CA`](@ref), [`GPSL5I`](@ref).
+
+Its purpose is to carry the constellation-level facts that every GPS signal
+shares, so they can be stated once instead of per signal. The time system is
+the current example: `get_time_system(::Type{<:AbstractGPSSignal}) = GPST()`
+covers all GPS signals through subtype dispatch. Genuinely per-signal facts
+([`get_band`](@ref), [`get_modulation`](@ref), the chip rates …) stay defined
+on the concrete signal types.
+"""
+abstract type AbstractGPSSignal{C} <: AbstractGNSSSignal{C} end
+
+"""
+    AbstractGalileoSignal{C} <: AbstractGNSSSignal{C}
+
+Abstract supertype for a signal transmitted by the Galileo constellation, e.g.
+[`GalileoE1B`](@ref), [`GalileoE5aI`](@ref).
+
+The Galileo counterpart to [`AbstractGPSSignal`](@ref): it carries the facts
+every Galileo signal shares, e.g. `get_time_system(::Type{<:AbstractGalileoSignal})
+= GST()`.
+"""
+abstract type AbstractGalileoSignal{C} <: AbstractGNSSSignal{C} end
 
 Base.Broadcast.broadcastable(s::AbstractGNSSSignal) = Ref(s)
 

--- a/src/galileo/e1b.jl
+++ b/src/galileo/e1b.jl
@@ -1,5 +1,5 @@
 """
-    GalileoE1B{C} <: AbstractGNSSSignal{C}
+    GalileoE1B{C} <: AbstractGalileoSignal{C}
 
 Galileo E1B signal (the data-carrying component of Galileo E1 OS).
 
@@ -14,7 +14,7 @@ get_code_length(e1b)   # 4092
 get_band(e1b)          # L1()
 ```
 """
-struct GalileoE1B{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GalileoE1B{C<:AbstractMatrix} <: AbstractGalileoSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end
@@ -149,7 +149,7 @@ julia> get_data_frequency(GalileoE1B())
 end
 
 """
-    GalileoE1B_BOC11{C} <: AbstractGNSSSignal{C}
+    GalileoE1B_BOC11{C} <: AbstractGalileoSignal{C}
 
 BOC(1,1) approximation of Galileo E1B (the data-carrying component of
 Galileo E1 OS).
@@ -178,7 +178,7 @@ get_modulation(e1b)    # BOCsin(1, 1)
 get_code_length(e1b)   # 4092
 ```
 """
-struct GalileoE1B_BOC11{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GalileoE1B_BOC11{C<:AbstractMatrix} <: AbstractGalileoSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end

--- a/src/galileo/e1c.jl
+++ b/src/galileo/e1c.jl
@@ -1,5 +1,5 @@
 """
-    GalileoE1C{C} <: AbstractGNSSSignal{C}
+    GalileoE1C{C} <: AbstractGalileoSignal{C}
 
 Galileo E1C signal (the pilot, dataless component of Galileo E1 OS).
 
@@ -25,7 +25,7 @@ get_secondary_code_length(e1c)  # 25
 get_band(e1c)                   # L1()
 ```
 """
-struct GalileoE1C{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GalileoE1C{C<:AbstractMatrix} <: AbstractGalileoSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end
@@ -168,7 +168,7 @@ julia> get_data_frequency(GalileoE1C())
 end
 
 """
-    GalileoE1C_BOC11{C} <: AbstractGNSSSignal{C}
+    GalileoE1C_BOC11{C} <: AbstractGalileoSignal{C}
 
 BOC(1,1) approximation of Galileo E1C (the pilot component of Galileo E1
 OS).
@@ -198,7 +198,7 @@ get_modulation(e1c)    # BOCsin(1, 1)
 get_code_length(e1c)   # 4092
 ```
 """
-struct GalileoE1C_BOC11{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GalileoE1C_BOC11{C<:AbstractMatrix} <: AbstractGalileoSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end

--- a/src/galileo/e5a.jl
+++ b/src/galileo/e5a.jl
@@ -1,5 +1,5 @@
 """
-    GalileoE5aI{C} <: AbstractGNSSSignal{C}
+    GalileoE5aI{C} <: AbstractGalileoSignal{C}
 
 Galileo E5a-I signal (the in-phase, data-carrying component of Galileo E5a).
 
@@ -26,13 +26,13 @@ get_secondary_code_length(e5a_i)  # 20
 get_band(e5a_i)                   # L5()
 ```
 """
-struct GalileoE5aI{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GalileoE5aI{C<:AbstractMatrix} <: AbstractGalileoSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end
 
 """
-    GalileoE5aQ{C, M} <: AbstractGNSSSignal{C}
+    GalileoE5aQ{C, M} <: AbstractGalileoSignal{C}
 
 Galileo E5a-Q signal (the quadrature, dataless pilot component of Galileo E5a).
 
@@ -58,7 +58,7 @@ get_secondary_code_length(e5a_q)  # 100
 get_data_frequency(e5a_q)         # 0 Hz
 ```
 """
-struct GalileoE5aQ{C<:AbstractMatrix, M<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GalileoE5aQ{C<:AbstractMatrix, M<:AbstractMatrix} <: AbstractGalileoSignal{C}
     codes::C
     secondary_codes::M    # 100 × 50 Int8 ±1 matrix, exposed via PerPRNSecondaryCode
     lut::SignalLUT        # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`

--- a/src/gps/l1c_d.jl
+++ b/src/gps/l1c_d.jl
@@ -1,5 +1,5 @@
 """
-    GPSL1C_D{C} <: AbstractGNSSSignal{C}
+    GPSL1C_D{C} <: AbstractGPSSignal{C}
 
 GPS L1C data signal (the data-carrying component of L1C, broadcast by
 Block III/IIIF satellites alongside the legacy L1 C/A).
@@ -22,7 +22,7 @@ get_band(gpsl1c_d)          # L1()
 PRNs 1-63 are supported; PRNs 64-210 (IS-GPS-800G Table 6.3-1) are not
 implemented in this package.
 """
-struct GPSL1C_D{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GPSL1C_D{C<:AbstractMatrix} <: AbstractGPSSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end

--- a/src/gps/l1c_p.jl
+++ b/src/gps/l1c_p.jl
@@ -1,5 +1,5 @@
 """
-    GPSL1C_P{C, M} <: AbstractGNSSSignal{C}
+    GPSL1C_P{C, M} <: AbstractGPSSignal{C}
 
 GPS L1C pilot signal (the dataless component of L1C, carrying 75% of
 the L1C power per IS-GPS-800G; broadcast by Block III/IIIF satellites).
@@ -21,7 +21,7 @@ get_secondary_code_length(gpsl1c_p)  # 1800
 get_band(gpsl1c_p)                   # L1()
 ```
 """
-struct GPSL1C_P{C<:AbstractMatrix, M<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GPSL1C_P{C<:AbstractMatrix, M<:AbstractMatrix} <: AbstractGPSSignal{C}
     codes::C
     overlay_codes::M    # 1800 × 63 Int8 ±1 matrix, exposed via PerPRNSecondaryCode
     lut::SignalLUT      # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`

--- a/src/gps/l1ca.jl
+++ b/src/gps/l1ca.jl
@@ -1,5 +1,5 @@
 """
-    GPSL1CA{C} <: AbstractGNSSSignal{C}
+    GPSL1CA{C} <: AbstractGPSSignal{C}
 
 GPS L1 C/A signal.
 
@@ -14,7 +14,7 @@ get_code_length(gpsl1ca)   # 1023
 get_band(gpsl1ca)          # L1()
 ```
 """
-struct GPSL1CA{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GPSL1CA{C<:AbstractMatrix} <: AbstractGPSSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end

--- a/src/gps/l2c.jl
+++ b/src/gps/l2c.jl
@@ -1,5 +1,5 @@
 """
-    GPSL2CM{C} <: AbstractGNSSSignal{C}
+    GPSL2CM{C} <: AbstractGPSSignal{C}
 
 GPS L2 CM signal (the moderate-length, data-carrying component of the GPS L2
 civil signal L2C).
@@ -30,13 +30,13 @@ get_code_frequency(gpsl2cm)   # 511500 Hz
 get_band(gpsl2cm)             # L2()
 ```
 """
-struct GPSL2CM{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GPSL2CM{C<:AbstractMatrix} <: AbstractGPSSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end
 
 """
-    GPSL2CL{C} <: AbstractGNSSSignal{C}
+    GPSL2CL{C} <: AbstractGPSSignal{C}
 
 GPS L2 CL signal (the long, dataless pilot component of the GPS L2 civil
 signal L2C).
@@ -64,7 +64,7 @@ get_data_frequency(gpsl2cl)   # 0 Hz
 get_band(gpsl2cl)             # L2()
 ```
 """
-struct GPSL2CL{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GPSL2CL{C<:AbstractMatrix} <: AbstractGPSSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end

--- a/src/gps/l5.jl
+++ b/src/gps/l5.jl
@@ -1,5 +1,5 @@
 """
-    GPSL5I{C} <: AbstractGNSSSignal{C}
+    GPSL5I{C} <: AbstractGPSSignal{C}
 
 GPS L5-I signal (the in-phase, data-carrying component of GPS L5).
 
@@ -15,13 +15,13 @@ get_secondary_code_length(gpsl5i)  # 10
 get_band(gpsl5i)                   # L5()
 ```
 """
-struct GPSL5I{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GPSL5I{C<:AbstractMatrix} <: AbstractGPSSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end
 
 """
-    GPSL5Q{C} <: AbstractGNSSSignal{C}
+    GPSL5Q{C} <: AbstractGPSSignal{C}
 
 GPS L5-Q signal (the quadrature, dataless pilot component of GPS L5).
 
@@ -44,7 +44,7 @@ get_data_frequency(gpsl5q)         # 0 Hz
 get_band(gpsl5q)                   # L5()
 ```
 """
-struct GPSL5Q{C<:AbstractMatrix} <: AbstractGNSSSignal{C}
+struct GPSL5Q{C<:AbstractMatrix} <: AbstractGPSSignal{C}
     codes::C
     lut::SignalLUT    # embedded per-signal LUT, always populated; see `build_signal_lut` / `gen_code!`
 end

--- a/src/time_systems.jl
+++ b/src/time_systems.jl
@@ -96,9 +96,11 @@ $(SIGNATURES)
 
 Get the [`TimeSystem`](@ref) a signal's measurements are referenced to.
 
-Concrete signal types define one method each on the type, e.g.
-`get_time_system(::Type{<:GPSL1CA}) = GPST()`, so the time system is available
-without constructing a signal. The instance method forwards to the type.
+The time system is a per-constellation fact, so it is defined once per
+constellation on the signal supertype, e.g.
+`get_time_system(::Type{<:AbstractGPSSignal}) = GPST()`; every concrete GPS
+signal inherits it through subtype dispatch. Available on the type (without
+constructing a signal); the instance method forwards to the type.
 
 # Examples
 ```julia-repl
@@ -113,24 +115,12 @@ function get_time_system end
 
 @inline get_time_system(s::AbstractGNSSSignal) = get_time_system(typeof(s))
 
-# Signal → time system. This is the only genuinely per-signal fact here (like
-# the per-signal `get_band`); the epoch and TAI offset are properties of the
-# time system, defined once above.
-# GPS signals: GPS Time.
-@inline get_time_system(::Type{<:GPSL1CA}) = GPST()
-@inline get_time_system(::Type{<:GPSL1C_D}) = GPST()
-@inline get_time_system(::Type{<:GPSL1C_P}) = GPST()
-@inline get_time_system(::Type{<:GPSL2CM}) = GPST()
-@inline get_time_system(::Type{<:GPSL2CL}) = GPST()
-@inline get_time_system(::Type{<:GPSL5I}) = GPST()
-@inline get_time_system(::Type{<:GPSL5Q}) = GPST()
-# Galileo signals: Galileo System Time.
-@inline get_time_system(::Type{<:GalileoE1B}) = GST()
-@inline get_time_system(::Type{<:GalileoE1B_BOC11}) = GST()
-@inline get_time_system(::Type{<:GalileoE1C}) = GST()
-@inline get_time_system(::Type{<:GalileoE1C_BOC11}) = GST()
-@inline get_time_system(::Type{<:GalileoE5aI}) = GST()
-@inline get_time_system(::Type{<:GalileoE5aQ}) = GST()
+# Signal → time system. This is a per-constellation fact, so it is stated once
+# per constellation through the signal supertype (unlike the genuinely
+# per-signal `get_band`); the epoch and TAI offset are properties of the time
+# system, defined once above.
+@inline get_time_system(::Type{<:AbstractGPSSignal}) = GPST()         # GPS Time
+@inline get_time_system(::Type{<:AbstractGalileoSignal}) = GST()      # Galileo System Time
 
 # Signal-level access forwards through the time system — same dual entry (type
 # or instance) as `get_center_frequency` through `get_band`.

--- a/test/time_systems.jl
+++ b/test/time_systems.jl
@@ -9,7 +9,20 @@ import Unitful: s
     @test GPST <: TimeSystem
     @test GST <: TimeSystem
 
-    # Signal → time system (the only per-signal fact).
+    # Every signal belongs to its constellation supertype; both supertypes are
+    # signal subtypes. This is what lets `get_time_system` be stated once per
+    # constellation.
+    @test AbstractGPSSignal <: AbstractGNSSSignal
+    @test AbstractGalileoSignal <: AbstractGNSSSignal
+    for S in gps_signals
+        @test S <: AbstractGPSSignal
+    end
+    for S in galileo_signals
+        @test S <: AbstractGalileoSignal
+    end
+
+    # Signal → time system (a per-constellation fact, dispatched via the
+    # constellation supertype).
     for S in gps_signals
         @test @inferred(get_time_system(S)) === GPST()
     end


### PR DESCRIPTION
## Summary

Introduces two intermediate abstract supertypes between `AbstractGNSSSignal`
and the concrete signal types:

```julia
abstract type AbstractGPSSignal{C}     <: AbstractGNSSSignal{C} end
abstract type AbstractGalileoSignal{C} <: AbstractGNSSSignal{C} end
```

Each concrete signal now subtypes its constellation (`GPSL1CA <: AbstractGPSSignal`,
`GalileoE1B <: AbstractGalileoSignal`, …).

## Motivation

The time system is a **per-constellation** fact — every GPS signal is referenced
to `GPST`, every Galileo signal to `GST` — yet `get_time_system` was spelled out
once per signal (13 near-identical methods). The signal type hierarchy had no
place to express "this belongs to GPS", so the constellation-level fact had to be
repeated per leaf type.

With a constellation supertype, membership is encoded at the `struct … <: …`
definition site (the line you write anyway, so **zero extra lines**), and the
time system is stated once per constellation via subtype dispatch:

```julia
get_time_system(::Type{<:AbstractGPSSignal})     = GPST()
get_time_system(::Type{<:AbstractGalileoSignal}) = GST()
```

13 methods → 2. New signals inherit the correct time system with nothing to
remember. Genuinely per-signal facts (`get_band`, `get_modulation`, chip rates)
stay on the concrete types.

## Changes

- Add + export `AbstractGPSSignal` / `AbstractGalileoSignal` (with docstrings).
- Repoint all 13 concrete signal structs at their constellation supertype.
- Collapse `get_time_system` to one method per constellation; update the
  docstring and inline comment (which previously mislabeled the time system as a
  "per-signal" fact).
- Add the two supertypes to `docs/src/api.md`.
- Add tests asserting each signal is a subtype of its constellation supertype,
  and that both supertypes are subtypes of `AbstractGNSSSignal`.

## Performance

Zero impact — pure compile-time dispatch. Verified `get_time_system(sig)`
constant-folds to `return GPST()` with **0 allocations** and is inferred to the
singleton type `GPST` (downstream `get_tai_offset(GPSL1CA)` folds to `19 s`).
Abstract-supertype dispatch is resolved during specialization; emitted code is
identical to before.

## Testing

- Full suite passes locally; "Time systems" testset now 79/79.
- Docs build (`docs/make.jl`, `checkdocs = :exports`) passes with the two new
  exported types documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
