### PR TITLE
feat(code): add get_code_amplitude accessor for the code's RMS amplitude

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -97,6 +97,7 @@ GNSSSignals.code_width
 GNSSSignals.get_code
 GNSSSignals.get_code_unsafe
 GNSSSignals.get_codes
+GNSSSignals.get_code_amplitude
 ```
 
 ## Signal Properties

--- a/src/GNSSSignals.jl
+++ b/src/GNSSSignals.jl
@@ -45,6 +45,7 @@ export AbstractGNSSSignal,
     get_code_frequency,
     get_code,
     get_code_unsafe,
+    get_code_amplitude,
     get_data_frequency,
     get_code_center_frequency_ratio,
     get_code_spectrum,
@@ -137,6 +138,14 @@ struct SignalLUT
     secondary::Matrix{Int8}
     table_length::Int         # L·P (length of one PRN's baked table, i.e. column length minus WINDOW_PAD)
     period_subchips::Int      # sub-chips per primary period (Lp·P), for secondary application
+    # Per-sample RMS amplitude of the baked code, `sqrt(mean(code^2))` over one primary
+    # table. Exactly `1` for ±1 codes (BPSK/BOC/TMBOC); for the multi-level CBOC Int8
+    # approximation it is `sqrt(a1^2 + a2^2)` (≈ 19.92 for E1B's baked (19, 6)) and tracks
+    # any explicit `cboc_amplitudes` override. Modulation-level and PRN-independent (PRNs
+    # differ only in the primary ±1 sign), so one scalar suffices. Read via
+    # `get_code_amplitude`; consumers divide correlation results by it to recover a
+    # modulation-independent (unit-power) scale.
+    code_amplitude::Float64
 end
 
 # Residual secondary column for PRN `prn` (the shared-secondary matrix has one column reused

--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -328,8 +328,47 @@ function build_signal_lut(modulation, codes::AbstractMatrix, sec::SecondaryCode;
         @inbounds padded[:, prn] .= mc.table.padded
         residual_perprn && (@inbounds secmat[:, prn] .= mc.secondary)
     end
-    SignalLUT(padded, mc1.subchip_factor, secmat, mc1.table.length, mc1.period_subchips)
+    # Per-sample RMS amplitude of the baked code (see `SignalLUT.code_amplitude`). Computed
+    # once here from PRN 1's table — modulation-level and PRN-independent (all PRNs share the
+    # sub-carrier magnitude pattern; the primary only flips signs). Widen to `Int` before
+    # squaring: `abs2` on `Int8` overflows for CBOC's ±25 (25^2 = 625 wraps).
+    tbl = @view mc1.table.padded[1:mc1.table.length]
+    code_amplitude = sqrt(sum(x -> abs2(Int(x)), tbl) / length(tbl))
+    SignalLUT(
+        padded,
+        mc1.subchip_factor,
+        secmat,
+        mc1.table.length,
+        mc1.period_subchips,
+        code_amplitude,
+    )
 end
+
+"""
+$(SIGNATURES)
+
+Per-sample RMS amplitude of `signal`'s sampled code replica — `sqrt(mean(code^2))`
+over one primary code period.
+
+Returns exactly `1` for every ±1 code (BPSK/BOC/TMBOC). For the multi-level CBOC
+Int8 approximation (Galileo E1B/E1C) it is `sqrt(a1^2 + a2^2)` for the baked integer
+sub-carrier amplitudes `(a1, a2)` — ≈ `19.92` for E1B's default `(19, 6)` — and
+reflects any explicit `cboc_amplitudes` override passed to `build_signal_lut`.
+
+Divide a correlation result by this to recover a modulation-independent (unit-power)
+amplitude scale, matching the sqrt-power convention of the old float codes: without
+it a CBOC prompt is scaled up by the code's integer amplitude relative to a BPSK one.
+
+# Examples
+```julia-repl
+julia> get_code_amplitude(GPSL1CA())
+1.0
+
+julia> get_code_amplitude(GalileoE1B())   # sqrt(19^2 + 6^2)
+19.924858845171276
+```
+"""
+@inline get_code_amplitude(signal::AbstractGNSSSignal) = signal.lut.code_amplitude
 
 # Primary ±1 column for PRN `prn` from the (Int16) code matrix — sign of each stored chip.
 @inline _primary_col(codes::AbstractMatrix, prn::Integer) =

--- a/test/code_lut.jl
+++ b/test/code_lut.jl
@@ -880,6 +880,22 @@ end
         end
     end
 
+    @testset "get_code_amplitude reflects the baked table (incl. overrides)" begin
+        # The default embedded bake (19, 6): amplitude is the RMS of the ±13/±25 table.
+        tbl = Int.(signal.lut.padded[1:signal.lut.table_length, prn])
+        @test get_code_amplitude(signal) ≈ sqrt(sum(abs2, tbl) / length(tbl))
+        @test get_code_amplitude(signal) ≈ sqrt(19.0^2 + 6.0^2)
+        # An explicit `cboc_amplitudes` override is stored on the LUT — the accessor tracks
+        # it, so a re-derivation from `boc1_power` (which ignores overrides) would be wrong.
+        for (a1, a2) in ((30, 9), (2, 1))
+            lut = GNSSSignals.build_signal_lut(
+                get_modulation(signal), get_codes(signal), NoSecondaryCode();
+                cboc_amplitudes = (a1, a2),
+            )
+            @test lut.code_amplitude ≈ sqrt(Float64(a1)^2 + a2^2)
+        end
+    end
+
     @testset "matches float CBOC (signs exact; correlation tracks the amplitude ratio)" begin
         # At fs = fc·P (integer ratio P) every sample is exactly one sub-chip, so the LUT and
         # the float CBOC align sub-chip-for-sub-chip: the sign pattern is identical for ALL

--- a/test/common.jl
+++ b/test/common.jl
@@ -6,8 +6,14 @@
 ]
     if get_modulation(signal) isa GNSSSignals.CBOC
         @test get_code_type(signal) == Float32
+        # Multi-level CBOC: amplitude is the RMS of the baked ±13/±25 sub-carrier table,
+        # sqrt(19^2 + 6^2) for E1's (19, 6) split (both E1B and E1C, boc2_sign aside).
+        tbl = Int.(signal.lut.padded[1:signal.lut.table_length, 1])
+        @test get_code_amplitude(signal) ≈ sqrt(sum(abs2, tbl) / length(tbl))
+        @test get_code_amplitude(signal) ≈ sqrt(19.0^2 + 6.0^2)
     else
         @test get_code_type(signal) == Int16
+        @test get_code_amplitude(signal) == 1.0          # ±1 code
     end
     @test get_codes(signal) == signal.codes
 end


### PR DESCRIPTION
## Summary

The embedded Int8 LUT emits a ±1 replica for BPSK/BOC/TMBOC, but a **multi-level integer approximation** for CBOC (Galileo E1B/E1C: sub-carrier levels ±13/±25). A correlation against that replica is therefore scaled by the code's amplitude. Consumers — e.g. Tracking's correlator normalization — need that scale to recover a modulation-independent, unit-power amplitude, but nothing exposed it. (Downstream, Tracking had been re-deriving it by mirroring the private `_cboc_int_amplitudes`, which is fragile and wrong under an explicit amplitude override.)

## What this adds

`get_code_amplitude(signal)` — the per-sample RMS amplitude `sqrt(mean(code²))` of the baked code:

- **Exactly `1`** for every ±1 code (BPSK/BOC/TMBOC).
- **`sqrt(a1² + a2²)`** for the CBOC integer approximation — ≈ `19.92` for E1B's default `(19, 6)`.

It's computed **once at bake time** from the baked table and stored on `SignalLUT` (new `code_amplitude::Float64` field), so the accessor is O(1). Because it reads the actual baked table, it automatically **reflects any explicit `cboc_amplitudes` override** — no re-derivation from `boc1_power` that would silently ignore overrides.

## Tests
- `test/common.jl`: per-signal — `1.0` for L1CA/L5I, and the baked-table RMS (= `sqrt(19²+6²)`) for E1B/E1C.
- `test/code_lut.jl`: the default `(19,6)` amplitude equals the RMS of the baked ±13/±25 table, **and** an explicit `cboc_amplitudes=(30,9)`/`(2,1)` override is reflected (`sqrt(a1²+a2²)`).

Full `Pkg.test()` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)