### PR TITLE
perf(code): lower AVX-512 boundary crossover 10 → 8

### DIFF
--- a/src/code_lut/kernel.jl
+++ b/src/code_lut/kernel.jl
@@ -621,8 +621,8 @@ end
 # crossover is where one W-lane permute block (cost ≈ flat per block) equals ~W/m boundary
 # stores (cost ≈ flat per chip), so it scales with the backend's block width — wider
 # vectors amortise the permute over more samples and push the switch to higher m. Values
-# are the measured curve crossings (Zen 5 AVX-512: boundary overtakes the split-constant
-# permute at m ≈ 10; AVX2 = 3, matching the old run-fill values — on the CI AVX2
+# are the measured curve crossings (Zen 5 AVX-512: boundary overtakes the `cmhi` split-constant
+# permute at m ≈ 8; AVX2 = 3, matching the old run-fill values — on the CI AVX2
 # runner the m ≈ 3.9 rows (GPSL5 @ 40 MHz) lose ~20 % when sent to the permute instead).
 # NEON is microarchitecture-split (one constant cannot fit both aarch64 families — their
 # permute/boundary curves cross at OPPOSITE points):
@@ -637,11 +637,18 @@ end
 # `Sys.isapple()` const-folds at precompile; aarch64+macOS ⇒ Apple Silicon, aarch64+Linux ⇒ Cortex
 # (Jetson/Raspberry Pi/Neoverse). Was `= 3` for all NEON (copied untuned from AVX2, which sent the
 # common Cortex GPS L1 C/A / L5 rows to the slower boundary path).
+# AVX-512 = 8 (was 10). Re-measured on a Zen 5 after the `cmhi` permute rewrite (~45% faster
+# there): with a clock stabilised near all-core boost (so the ALU-heavy permute and the store-heavy
+# boundary see the same clock — a single-core-boost measurement biases toward the store kernel), the
+# permute is a flat ~0.025 ns/sample and boundary overtakes it at m ≥ 8 (m=8 boundary 0.0199 vs
+# permute 0.0253, ~21% faster; m=9 ~4%). The old `= 10` left m=8..9 on the now-slower permute. 8 is
+# also safe on Intel AVX-512, where zmm-heavy code down-licenses the core clock and pushes the
+# crossover even lower (boundary favoured), so no x86 AVX-512 part wants a threshold above 8.
 # Near the crossover both kernels are within ~15 % of each other, so the
 # exact values are uncritical — and since both kernels are EXACT and N-independent, the
 # choice affects only speed, never output (the old N-aware short-fill overload is gone:
 # neither kernel has a meaningful setup cost).
-@inline _boundary_min_m(::AVX512)   = 10
+@inline _boundary_min_m(::AVX512)   = 8
 @inline _boundary_min_m(::AVX2)     = 3
 @inline _boundary_min_m(::Neon)     = Sys.isapple() ? 3 : 6
 @inline _boundary_min_m(::Portable) = 2


### PR DESCRIPTION
## Summary

Follow-up to the `cmhi` permute rewrite (#146). That change made the AVX-512 `vpermb` permute ~45% faster, which shifts where the boundary fill becomes the better choice — so the `_boundary_min_m(::AVX512)` crossover was re-measured and lowered **10 → 8**.

## Measurement (Zen 5, AVX-512)

Measured with the core clock **stabilised near all-core boost** (a background all-core load), so the ALU-heavy permute and the store-heavy boundary fill are compared at the *same* clock — a single-core-boost measurement lets the store kernel hold a higher clock and biases the crossover. Validity check: the permute came out **flat at ~0.025 ns/sample across all m** (it swings 0.024–0.039 when the clock isn't stabilised).

| m | permute | boundary | winner |
|--:|--:|--:|:--|
| 6 | 0.0251 | 0.0350 | permute |
| 7 | 0.0234 | 0.0311 | permute |
| **8** | 0.0253 | **0.0199** | **boundary — ~21% faster** |
| 9 | 0.0254 | 0.0243 | boundary — ~4% |
| 10 | 0.0255 | 0.0216 | boundary |
| ≥11 | ~0.025 | falling | boundary |

The old `= 10` left the m = 8..9 band (≈8–9× oversampling — e.g. the suite's `08x` rows) on the now-slower permute.

## Why 8 is safe across x86 AVX-512

On **Intel** AVX-512, zmm-heavy code down-licenses the core clock, making the permute relatively slower and pushing the crossover *even lower* (boundary favoured). So no x86 AVX-512 part wants a threshold above 8 — 8 is a good single constant, and strictly better than 10.

## Scope / correctness

- **AVX-512 only.** NEON (`Sys.isapple() ? 3 : 6`) and AVX2 (`3`) are unchanged.
- AVX2 was also measured on this box (crossover ≈ 6–7 on Zen 5), but the `cmhi` rewrite was **neutral** for AVX2 (no shift), and the current `= 3` was tuned on the Intel CI AVX2 runner where boundary at m≈3.9 was ~20% faster — the opposite of Zen 5. That Intel-vs-Zen split is pre-existing and shouldn't be retuned off a single box, so AVX2 is left alone.
- Pure path-selection change: both kernels are EXACT and N-independent ⇒ **output unchanged**. Full test suite passes on real AVX-512 hardware (Zen 5).
- The `08x` oversampling rows in the benchmark CI exercise exactly this m=8 case and will confirm on the runner hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)