### PR TITLE
fix(ci): serialize push-triggered Documentation runs to stop gh-pages race

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -7,13 +7,19 @@ on:
     tags: '*'
   pull_request:
 
-# Serialize Documentation runs per ref. Two parallel `pull_request`
-# events on the same PR (e.g. from a force-push immediately after a
-# previous push) otherwise race on the final `git push` to `gh-pages`
-# and one always fails with `[rejected] HEAD -> gh-pages (fetch first)`.
+# Serialize Documentation runs. Two parallel `pull_request` events on
+# the same PR (e.g. from a force-push immediately after a previous
+# push) otherwise race on the final `git push` to `gh-pages` and one
+# always fails with `[rejected] HEAD -> gh-pages (fetch first)`. Push
+# events (branch + tag) hit the same problem: a release tag pushed
+# right after the master commit runs concurrently with master's own
+# Documentation job, and both push to `gh-pages` — grouping those by
+# `github.ref` doesn't help since the branch and tag refs differ. So
+# all push events share a single group and queue instead of racing;
+# only pull_request runs are safe to cancel outright.
 concurrency:
-  group: documentation-${{ github.ref }}
-  cancel-in-progress: true
+  group: documentation-${{ github.event_name == 'pull_request' && github.ref || 'gh-pages-deploy' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- The Documentation workflow's concurrency group was keyed on `github.ref`, so a release tag push (`refs/tags/v3.4.2`) and its accompanying master push (`refs/heads/master`) landed in different groups and ran concurrently.
- Both jobs deploy to the `gh-pages` branch; the one that pushes second loses with `[rejected] HEAD -> gh-pages (fetch first)`, which is exactly what's failing on master right now (e.g. runs [28881361588](https://github.com/JuliaGNSS/GNSSSignals.jl/actions/runs/28881361588), [28878011296](https://github.com/JuliaGNSS/GNSSSignals.jl/actions/runs/28878011296)).
- Fix: push events (branch + tag) now share a single concurrency group so they queue instead of racing. `pull_request` runs keep their original per-ref group with `cancel-in-progress: true` so force-pushes still cancel stale runs.

## Test plan
- [ ] Merge to master and push a follow-up release tag; confirm both the `master` and `vX.Y.Z` Documentation jobs succeed without the gh-pages push race.