### PR TITLE
feat(api): add name and id accessors; de-duplicate the accessor layer

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -30,6 +30,7 @@ GNSSSignals.L2
 GNSSSignals.L5
 GNSSSignals.get_band
 GNSSSignals.get_band_id
+GNSSSignals.get_band_name
 ```
 
 ## Time Systems
@@ -39,6 +40,8 @@ GNSSSignals.TimeSystem
 GNSSSignals.GPST
 GNSSSignals.GST
 GNSSSignals.get_time_system
+GNSSSignals.get_time_system_id
+GNSSSignals.get_time_system_name
 GNSSSignals.get_system_start_time
 GNSSSignals.get_tai_offset
 ```
@@ -115,6 +118,7 @@ GNSSSignals.get_carrier_phase_offset
 GNSSSignals.get_signal_name
 GNSSSignals.get_signal_id
 GNSSSignals.get_constellation_id
+GNSSSignals.get_constellation_name
 GNSSSignals.min_bits_for_code_length
 GNSSSignals.get_code_type
 ```

--- a/src/GNSSSignals.jl
+++ b/src/GNSSSignals.jl
@@ -52,13 +52,17 @@ export AbstractGNSSSignal,
     get_code_spectrum,
     get_band,
     get_band_id,
+    get_band_name,
     get_signal_id,
     get_constellation_id,
+    get_constellation_name,
     get_signal_name,
     TimeSystem,
     GPST,
     GST,
     get_time_system,
+    get_time_system_id,
+    get_time_system_name,
     get_system_start_time,
     get_tai_offset,
     min_bits_for_code_length,
@@ -95,9 +99,12 @@ Abstract supertype for a signal transmitted by the GPS constellation, e.g.
 [`GPSL1CA`](@ref), [`GPSL5I`](@ref).
 
 Its purpose is to carry the constellation-level facts that every GPS signal
-shares, so they can be stated once instead of per signal. The time system is
-the current example: `get_time_system(::Type{<:AbstractGPSSignal}) = GPST()`
-covers all GPS signals through subtype dispatch. Genuinely per-signal facts
+shares, so they can be stated once instead of per signal: the time system
+([`get_time_system`](@ref), and with it [`get_time_system_id`](@ref) /
+[`get_time_system_name`](@ref)) and the constellation identity
+([`get_constellation_id`](@ref) / [`get_constellation_name`](@ref)). Each is one
+method on this type — `get_time_system(::Type{<:AbstractGPSSignal}) = GPST()` —
+covering all GPS signals through subtype dispatch. Genuinely per-signal facts
 ([`get_band`](@ref), [`get_modulation`](@ref), the chip rates …) stay defined
 on the concrete signal types.
 """

--- a/src/bands.jl
+++ b/src/bands.jl
@@ -43,16 +43,22 @@ $(SIGNATURES)
 
 Get the center (carrier) frequency of a band.
 
+One method per concrete [`Band`](@ref) — `L1` 1575.42 MHz, `L2` 1227.6 MHz,
+`L5` 1176.45 MHz. Works on a band instance or its type, as
+[`get_band_id`](@ref) / [`get_band_name`](@ref) do.
+
 ```julia-repl
 julia> get_center_frequency(L1())
 1575420000 Hz
+
+julia> get_center_frequency(L5)
+1176450000 Hz
 ```
 """
-@inline get_center_frequency(::L1) = 1_575_420_000Hz
-
-@inline get_center_frequency(::L2) = 1_227_600_000Hz
-
-@inline get_center_frequency(::L5) = 1_176_450_000Hz
+@inline get_center_frequency(::Type{L1}) = 1_575_420_000Hz
+@inline get_center_frequency(::Type{L2}) = 1_227_600_000Hz
+@inline get_center_frequency(::Type{L5}) = 1_176_450_000Hz
+@inline get_center_frequency(b::Band) = get_center_frequency(typeof(b))
 
 """
 $(SIGNATURES)
@@ -84,6 +90,20 @@ Get the [`Band`](@ref) a signal is transmitted on.
 Concrete signal types define one method each on the type, e.g.
 `get_band(::Type{<:GPSL1CA}) = L1()`, so the band is available without
 constructing a signal. The instance method forwards to the type.
+
+Band identity is by RF frequency, so signals of different constellations sharing
+a carrier report the same band — `get_band(GalileoE1B())` is `L1()`. See
+[`get_band_id`](@ref) / [`get_band_name`](@ref) for the band's key and label, and
+[`get_center_frequency`](@ref) for its carrier frequency.
+
+# Examples
+```julia-repl
+julia> get_band(GPSL1CA())
+L1()
+
+julia> get_band(GalileoE5aI)
+L5()
+```
 """
 function get_band end
 
@@ -120,3 +140,49 @@ julia> get_band_id(GPSL1CA())
 @inline get_band_id(b::Band) = get_band_id(typeof(b))
 @inline get_band_id(::Type{S}) where {S<:AbstractGNSSSignal} = get_band_id(get_band(S))
 @inline get_band_id(s::AbstractGNSSSignal) = get_band_id(get_band(s))
+
+"""
+$(SIGNATURES)
+
+Get the human-readable name of a [`Band`](@ref), e.g. `"L1"`, `"L5"`.
+
+The display counterpart to [`get_band_id`](@ref) — same granularity, but a
+`String` meant for log lines and user-facing output rather than a key to
+branch or dictionary on (prefer the `Symbol` id for that; comparing symbols is
+cheaper and the name is free to be respelled).
+
+Band identity is by RF frequency, so the name is the *band's* label, not the
+constellation's label for it: `get_band_name(GalileoE1B())` is `"L1"`, not
+`"E1"`. Use [`get_signal_name`](@ref) (`"Galileo E1B"`) when you need the
+ICD-specific naming.
+
+Stated as a literal per band — `get_band_name(::Type{L1}) = "L1"` — so naming a
+band is free: the call allocates nothing and folds to a compile-time constant.
+Each literal still spells exactly what `String` of [`get_band_id`](@ref) yields,
+and a test pins that, so the two identity layers cannot drift apart.
+
+A [`Band`](@ref) declared elsewhere needs no method of its own: the
+`String(get_band_id(B))` fallback names it for free. That path allocates a fresh
+`String` on every call (32 bytes, measured) even where the band type is
+statically known, because a heap-allocated `String` — unlike an interned `Symbol`
+or a literal already in the method's source — cannot be baked into the IR as a
+constant. State the name as a literal, as the bands here do, if you are naming
+such a band in a hot loop rather than a log line.
+
+Works on a band or signal, instance or type.
+
+```julia-repl
+julia> get_band_name(L1())
+"L1"
+
+julia> get_band_name(GPSL1CA())
+"L1"
+```
+"""
+@inline get_band_name(::Type{L1}) = "L1"
+@inline get_band_name(::Type{L2}) = "L2"
+@inline get_band_name(::Type{L5}) = "L5"
+@inline get_band_name(::Type{B}) where {B<:Band} = String(get_band_id(B))
+@inline get_band_name(b::Band) = get_band_name(typeof(b))
+@inline get_band_name(::Type{S}) where {S<:AbstractGNSSSignal} = get_band_name(get_band(S))
+@inline get_band_name(s::AbstractGNSSSignal) = get_band_name(get_band(s))

--- a/src/common.jl
+++ b/src/common.jl
@@ -85,6 +85,40 @@ julia> get_signal_id(GalileoE1B)
 """
 $(SIGNATURES)
 
+Get the human-readable name of a GNSS signal, e.g. `"GPS L1 C/A"`,
+`"Galileo E5a-Q"`.
+
+This is the display counterpart to [`get_signal_id`](@ref), at the same (finest)
+identity level: it names one specific transmission, component included. The
+spelling follows the ICD rather than the type name, so it is meant for log lines,
+plot labels and user-facing output — prefer the `Symbol` id when branching or
+keying. The BOC(1,1) approximation types name themselves as such (`"Galileo E1B
+(BOC(1,1) approximation)"`), so a label never silently claims to be the exact
+signal.
+
+Genuinely per signal, so each concrete signal defines one method on its own type
+(`get_signal_name(::Type{<:GPSL1CA}) = "GPS L1 C/A"`, in that signal's file),
+mirroring [`get_band`](@ref); the instance method forwards to the type, so the
+name is available without constructing a signal.
+
+Finer than [`get_band_name`](@ref) (`"L1"`) and [`get_constellation_name`](@ref)
+(`"GPS"`).
+
+```julia-repl
+julia> get_signal_name(GPSL1CA())
+"GPS L1 C/A"
+
+julia> get_signal_name(GalileoE5aQ)
+"Galileo E5a-Q"
+```
+"""
+function get_signal_name end
+
+@inline get_signal_name(s::AbstractGNSSSignal) = get_signal_name(typeof(s))
+
+"""
+$(SIGNATURES)
+
 Get the `Symbol` identifier of the GNSS constellation a signal belongs to —
 `:GPS` or `:Galileo`.
 
@@ -113,6 +147,52 @@ julia> get_constellation_id(GalileoE1B)
 @inline get_constellation_id(::Type{<:AbstractGPSSignal}) = :GPS
 @inline get_constellation_id(::Type{<:AbstractGalileoSignal}) = :Galileo
 @inline get_constellation_id(s::AbstractGNSSSignal) = get_constellation_id(typeof(s))
+
+"""
+$(SIGNATURES)
+
+Get the human-readable name of the GNSS constellation a signal belongs to —
+`"GPS"` or `"Galileo"`.
+
+The display counterpart to [`get_constellation_id`](@ref) — same granularity
+(every signal of one constellation returns the same string), but a `String`
+meant for log lines and user-facing output rather than a key to branch or
+dictionary on (prefer the `Symbol` id for that; comparing symbols is cheaper
+and the name is free to be respelled).
+
+Stated as a literal once per constellation, on the abstract signal type
+(`get_constellation_name(::Type{<:AbstractGPSSignal}) = "GPS"`) as
+[`get_constellation_id`](@ref) is, so every concrete signal inherits the name
+without constructing a value, the call allocates nothing and it folds to a
+compile-time constant. Each literal still spells exactly what `String` of the id
+yields, and a test pins that, so the two layers cannot drift apart.
+
+A constellation added later needs no method of its own: the
+`String(get_constellation_id(S))` fallback names it for free — at the cost of
+allocating a fresh `String` on every call, for the reason spelled out at
+[`get_band_name`](@ref), whose derived fallback is built the same way. State a
+literal, as the constellations here do, if you are naming one in a hot loop, or
+wherever the display name differs from the id anyway: a future `:NavIC` reading
+`"NavIC (IRNSS)"`.
+
+Works on an instance or a type.
+
+Coarser than [`get_band_name`](@ref) (`"L1"`) and [`get_signal_name`](@ref)
+(`"GPS L1 C/A"`).
+
+```julia-repl
+julia> get_constellation_name(GPSL1CA())
+"GPS"
+
+julia> get_constellation_name(GalileoE1B)
+"Galileo"
+```
+"""
+@inline get_constellation_name(::Type{<:AbstractGPSSignal}) = "GPS"
+@inline get_constellation_name(::Type{<:AbstractGalileoSignal}) = "Galileo"
+@inline get_constellation_name(::Type{S}) where {S<:AbstractGNSSSignal} =
+    String(get_constellation_id(S))
+@inline get_constellation_name(s::AbstractGNSSSignal) = get_constellation_name(typeof(s))
 
 # Each concrete signal defines these on `::Type{<:Signal}` (per-signal files);
 # these forward an instance to its type.

--- a/src/galileo/e1b.jl
+++ b/src/galileo/e1b.jl
@@ -20,36 +20,10 @@ struct GalileoE1B{C<:AbstractMatrix} <: AbstractGalileoSignal{C}
 end
 
 get_modulation(::Type{<:GalileoE1B}) = CBOC(BOCsin(1, 1), BOCsin(6, 1), 10 / 11)
-@inline get_modulation(::GalileoE1B) = CBOC(BOCsin(1, 1), BOCsin(6, 1), 10 / 11)
 
-"""
-$(SIGNATURES)
-
-Get the band the signal is transmitted on.
-
-Galileo E1 shares the L1 carrier frequency (1575.42 MHz), so this returns
-[`L1`](@ref) — band identity is by RF, not by ICD label.
-
-# Examples
-```julia-repl
-julia> get_band(GalileoE1B())
-L1()
-```
-"""
 @inline get_band(::Type{<:GalileoE1B}) = L1()
 
-"""
-$(SIGNATURES)
-
-Get the human-readable signal name.
-
-# Examples
-```julia-repl
-julia> get_signal_name(GalileoE1B())
-"Galileo E1B"
-```
-"""
-get_signal_name(::GalileoE1B) = "Galileo E1B"
+@inline get_signal_name(::Type{<:GalileoE1B}) = "Galileo E1B"
 
 function read_from_documentation(raw_code)
     raw_code_without_spaces = replace(replace(raw_code, " " => ""), "\n" => "")
@@ -184,10 +158,9 @@ struct GalileoE1B_BOC11{C<:AbstractMatrix} <: AbstractGalileoSignal{C}
 end
 
 get_modulation(::Type{<:GalileoE1B_BOC11}) = BOCsin(1, 1)
-@inline get_modulation(::GalileoE1B_BOC11) = BOCsin(1, 1)
 
 @inline get_band(::Type{<:GalileoE1B_BOC11}) = L1()
-get_signal_name(::GalileoE1B_BOC11) = "Galileo E1B (BOC(1,1) approximation)"
+@inline get_signal_name(::Type{<:GalileoE1B_BOC11}) = "Galileo E1B (BOC(1,1) approximation)"
 
 function GalileoE1B_BOC11()
     codes = widen_codes_to_storage(read_galileo_e1b_codes())

--- a/src/galileo/e1c.jl
+++ b/src/galileo/e1c.jl
@@ -31,36 +31,10 @@ struct GalileoE1C{C<:AbstractMatrix} <: AbstractGalileoSignal{C}
 end
 
 get_modulation(::Type{<:GalileoE1C}) = CBOC(BOCsin(1, 1), BOCsin(6, 1), 10 / 11, -1)
-@inline get_modulation(::GalileoE1C) = CBOC(BOCsin(1, 1), BOCsin(6, 1), 10 / 11, -1)
 
-"""
-$(SIGNATURES)
-
-Get the band the signal is transmitted on.
-
-Galileo E1 shares the L1 carrier frequency (1575.42 MHz), so this returns
-[`L1`](@ref) — band identity is by RF, not by ICD label.
-
-# Examples
-```julia-repl
-julia> get_band(GalileoE1C())
-L1()
-```
-"""
 @inline get_band(::Type{<:GalileoE1C}) = L1()
 
-"""
-$(SIGNATURES)
-
-Get the human-readable signal name.
-
-# Examples
-```julia-repl
-julia> get_signal_name(GalileoE1C())
-"Galileo E1C"
-```
-"""
-get_signal_name(::GalileoE1C) = "Galileo E1C"
+@inline get_signal_name(::Type{<:GalileoE1C}) = "Galileo E1C"
 
 function read_galileo_e1c_codes()
     read_in_codes(
@@ -204,10 +178,9 @@ struct GalileoE1C_BOC11{C<:AbstractMatrix} <: AbstractGalileoSignal{C}
 end
 
 get_modulation(::Type{<:GalileoE1C_BOC11}) = BOCsin(1, 1)
-@inline get_modulation(::GalileoE1C_BOC11) = BOCsin(1, 1)
 
 @inline get_band(::Type{<:GalileoE1C_BOC11}) = L1()
-get_signal_name(::GalileoE1C_BOC11) = "Galileo E1C (BOC(1,1) approximation)"
+@inline get_signal_name(::Type{<:GalileoE1C_BOC11}) = "Galileo E1C (BOC(1,1) approximation)"
 
 function GalileoE1C_BOC11()
     codes = widen_codes_to_storage(read_galileo_e1c_codes())

--- a/src/galileo/e5a.jl
+++ b/src/galileo/e5a.jl
@@ -233,43 +233,16 @@ end
 # Shared interface (band, modulation, frequencies).
 
 get_modulation(::Type{<:GalileoE5aI}) = LOC()
-@inline get_modulation(::GalileoE5aI) = LOC()
 get_modulation(::Type{<:GalileoE5aQ}) = LOC()
-@inline get_modulation(::GalileoE5aQ) = LOC()
 
 # E5aI data rides the in-phase carrier (default 0); E5aQ pilot is in quadrature.
 @inline get_carrier_phase_offset(::Type{<:GalileoE5aQ}) = π / 2
 
-"""
-$(SIGNATURES)
-
-Get the band the signal is transmitted on.
-
-Galileo E5a shares the GPS L5 carrier frequency (1176.45 MHz), so this returns
-[`L5`](@ref) — band identity is by RF, not by ICD label.
-
-# Examples
-```julia-repl
-julia> get_band(GalileoE5aI())
-L5()
-```
-"""
 @inline get_band(::Type{<:GalileoE5aI}) = L5()
 @inline get_band(::Type{<:GalileoE5aQ}) = L5()
 
-"""
-$(SIGNATURES)
-
-Get the human-readable signal name.
-
-# Examples
-```julia-repl
-julia> get_signal_name(GalileoE5aI())
-"Galileo E5a-I"
-```
-"""
-get_signal_name(::GalileoE5aI) = "Galileo E5a-I"
-get_signal_name(::GalileoE5aQ) = "Galileo E5a-Q"
+@inline get_signal_name(::Type{<:GalileoE5aI}) = "Galileo E5a-I"
+@inline get_signal_name(::Type{<:GalileoE5aQ}) = "Galileo E5a-Q"
 
 """
 $(SIGNATURES)

--- a/src/gps/l1c_d.jl
+++ b/src/gps/l1c_d.jl
@@ -28,21 +28,10 @@ struct GPSL1C_D{C<:AbstractMatrix} <: AbstractGPSSignal{C}
 end
 
 get_modulation(::Type{<:GPSL1C_D}) = BOCsin(1, 1)
-@inline get_modulation(::GPSL1C_D) = BOCsin(1, 1)
 
-"""
-$(SIGNATURES)
-
-Get the band the signal is transmitted on.
-"""
 @inline get_band(::Type{<:GPSL1C_D}) = L1()
 
-"""
-$(SIGNATURES)
-
-Get the human-readable signal name.
-"""
-get_signal_name(::GPSL1C_D) = "GPS L1C-D"
+@inline get_signal_name(::Type{<:GPSL1C_D}) = "GPS L1C-D"
 
 function read_gpsl1c_d_codes()
     _l1c_build_primary_codes(L1C_D_WEIL_INDEX, L1C_D_INSERTION_INDEX)

--- a/src/gps/l1c_p.jl
+++ b/src/gps/l1c_p.jl
@@ -30,21 +30,10 @@ end
 get_modulation(::Type{<:GPSL1C_P}) =
     TMBOC(BOCsin(1, 1), BOCsin(6, 1),
           ntuple(k -> (k - 1) ∈ L1C_TMBOC_BOC6_POSITIONS, Val(L1C_TMBOC_PERIOD)))
-@inline get_modulation(s::GPSL1C_P) = get_modulation(typeof(s))
 
-"""
-$(SIGNATURES)
-
-Get the band the signal is transmitted on.
-"""
 @inline get_band(::Type{<:GPSL1C_P}) = L1()
 
-"""
-$(SIGNATURES)
-
-Get the human-readable signal name.
-"""
-get_signal_name(::GPSL1C_P) = "GPS L1C-P"
+@inline get_signal_name(::Type{<:GPSL1C_P}) = "GPS L1C-P"
 
 function read_gpsl1c_p_codes()
     _l1c_build_primary_codes(L1C_P_WEIL_INDEX, L1C_P_INSERTION_INDEX)

--- a/src/gps/l1ca.jl
+++ b/src/gps/l1ca.jl
@@ -20,7 +20,6 @@ struct GPSL1CA{C<:AbstractMatrix} <: AbstractGPSSignal{C}
 end
 
 get_modulation(::Type{<:GPSL1CA}) = LOC()
-@inline get_modulation(::GPSL1CA) = LOC()
 
 # IS-GPS-200N Table 3-III designates the L1 P(Y) carrier as the band's in-phase (I)
 # reference; §3.3.1.5.1 puts the C/A carrier in quadrature, "lagging the P signal by
@@ -28,31 +27,9 @@ get_modulation(::Type{<:GPSL1CA}) = LOC()
 # and L1C are actually 90° apart; IS-GPS-800J §3.2.1.6.1.)
 @inline get_carrier_phase_offset(::Type{<:GPSL1CA}) = -π / 2
 
-"""
-$(SIGNATURES)
-
-Get the band the signal is transmitted on.
-
-# Examples
-```julia-repl
-julia> get_band(GPSL1CA())
-L1()
-```
-"""
 @inline get_band(::Type{<:GPSL1CA}) = L1()
 
-"""
-$(SIGNATURES)
-
-Get the human-readable signal name.
-
-# Examples
-```julia-repl
-julia> get_signal_name(GPSL1CA())
-"GPS L1 C/A"
-```
-"""
-get_signal_name(::GPSL1CA) = "GPS L1 C/A"
+@inline get_signal_name(::Type{<:GPSL1CA}) = "GPS L1 C/A"
 
 function read_gpsl1ca_codes()
     read_in_codes(

--- a/src/gps/l2c.jl
+++ b/src/gps/l2c.jl
@@ -131,9 +131,7 @@ end
 # Shared interface (modulation, band, frequencies).
 
 get_modulation(::Type{<:GPSL2CM}) = LOC()
-@inline get_modulation(::GPSL2CM) = LOC()
 get_modulation(::Type{<:GPSL2CL}) = LOC()
-@inline get_modulation(::GPSL2CL) = LOC()
 
 # IS-GPS-200N Table 3-III designates the L2 P(Y) carrier as the band's in-phase (I)
 # reference; the civil L2C component (the CM/CL chip-by-chip multiplex) rides the
@@ -143,33 +141,11 @@ get_modulation(::Type{<:GPSL2CL}) = LOC()
 @inline get_carrier_phase_offset(::Type{<:GPSL2CM}) = -π / 2
 @inline get_carrier_phase_offset(::Type{<:GPSL2CL}) = -π / 2
 
-"""
-$(SIGNATURES)
-
-Get the band the signal is transmitted on.
-
-# Examples
-```julia-repl
-julia> get_band(GPSL2CM())
-L2()
-```
-"""
 @inline get_band(::Type{<:GPSL2CM}) = L2()
 @inline get_band(::Type{<:GPSL2CL}) = L2()
 
-"""
-$(SIGNATURES)
-
-Get the human-readable signal name.
-
-# Examples
-```julia-repl
-julia> get_signal_name(GPSL2CM())
-"GPS L2CM"
-```
-"""
-get_signal_name(::GPSL2CM) = "GPS L2CM"
-get_signal_name(::GPSL2CL) = "GPS L2CL"
+@inline get_signal_name(::Type{<:GPSL2CM}) = "GPS L2CM"
+@inline get_signal_name(::Type{<:GPSL2CL}) = "GPS L2CL"
 
 """
 $(SIGNATURES)

--- a/src/gps/l5.jl
+++ b/src/gps/l5.jl
@@ -229,9 +229,7 @@ end
 # Shared interface (modulation, band, frequencies).
 
 get_modulation(::Type{<:GPSL5I}) = LOC()
-@inline get_modulation(::GPSL5I) = LOC()
 get_modulation(::Type{<:GPSL5Q}) = LOC()
-@inline get_modulation(::GPSL5Q) = LOC()
 
 # L5I data rides the in-phase carrier (default 0); L5Q pilot is in quadrature.
 # IS-GPS-705 §3.3.1.5: the Q5 carrier LAGS the I5 carrier by 90° (cos(ωt−π/2) = sin(ωt)),
@@ -239,33 +237,11 @@ get_modulation(::Type{<:GPSL5Q}) = LOC()
 # I·cos − Q·sin) puts the pilot at +π/2 (leading). Same modulation, opposite ICD convention.
 @inline get_carrier_phase_offset(::Type{<:GPSL5Q}) = -π / 2
 
-"""
-$(SIGNATURES)
-
-Get the band the signal is transmitted on.
-
-# Examples
-```julia-repl
-julia> get_band(GPSL5I())
-L5()
-```
-"""
 @inline get_band(::Type{<:GPSL5I}) = L5()
 @inline get_band(::Type{<:GPSL5Q}) = L5()
 
-"""
-$(SIGNATURES)
-
-Get the human-readable signal name.
-
-# Examples
-```julia-repl
-julia> get_signal_name(GPSL5I())
-"GPS L5-I"
-```
-"""
-get_signal_name(::GPSL5I) = "GPS L5-I"
-get_signal_name(::GPSL5Q) = "GPS L5-Q"
+@inline get_signal_name(::Type{<:GPSL5I}) = "GPS L5-I"
+@inline get_signal_name(::Type{<:GPSL5Q}) = "GPS L5-Q"
 
 """
 $(SIGNATURES)

--- a/src/modulation.jl
+++ b/src/modulation.jl
@@ -188,6 +188,11 @@ Get the modulation type for a GNSS signal.
 # Returns
 - `Modulation`: The modulation type (`LOC`, `BOCsin`, `BOCcos`, or `CBOC`)
 
+Each concrete signal states its modulation once, on its own type
+(`get_modulation(::Type{<:GPSL1CA}) = LOC()`, in that signal's file) — the form
+the code LUT is baked from; this method forwards an instance to that type, so
+the two can never disagree.
+
 # Examples
 ```julia-repl
 julia> get_modulation(GPSL1CA())
@@ -196,7 +201,7 @@ julia> get_modulation(GalileoE1B())
 CBOC{BOCsin{Int64, Int64}, BOCsin{Int64, Int64}}(BOCsin{Int64, Int64}(1, 1), BOCsin{Int64, Int64}(6, 1), 0.90909094f0)
 ```
 """
-get_modulation(signal::T) where {T<:AbstractGNSSSignal} = get_modulation(T)
+@inline get_modulation(signal::T) where {T<:AbstractGNSSSignal} = get_modulation(T)
 
 """
 $(SIGNATURES)

--- a/src/time_systems.jl
+++ b/src/time_systems.jl
@@ -131,3 +131,64 @@ function get_time_system end
 @inline get_tai_offset(::Type{S}) where {S<:AbstractGNSSSignal} =
     get_tai_offset(get_time_system(S))
 @inline get_tai_offset(s::AbstractGNSSSignal) = get_tai_offset(get_time_system(s))
+
+"""
+$(SIGNATURES)
+
+Get the `Symbol` identifier of a [`TimeSystem`](@ref) — `:GPST` or `:GST`.
+
+The machine-readable key for a time scale: the level at which signals share a
+receiver clock bias, so every signal referenced to the same scale maps to the
+same id. Its counterpart along the identity axis is [`get_constellation_id`](@ref)
+— currently one-to-one with it, but a distinct fact (a constellation can
+broadcast a scale it does not own).
+
+Defaults to `nameof` of the time system type, so a new [`TimeSystem`](@ref) gets
+a sensible id for free; override `get_time_system_id(::Type{MySystem})` if you
+need a different symbol. Works on a time system or signal, instance or type, and
+folds to a compile-time constant.
+
+```julia-repl
+julia> get_time_system_id(GPST())
+:GPST
+
+julia> get_time_system_id(GalileoE1B)
+:GST
+```
+"""
+@inline get_time_system_id(::Type{T}) where {T<:TimeSystem} = nameof(T)
+@inline get_time_system_id(t::TimeSystem) = get_time_system_id(typeof(t))
+@inline get_time_system_id(::Type{S}) where {S<:AbstractGNSSSignal} =
+    get_time_system_id(get_time_system(S))
+@inline get_time_system_id(s::AbstractGNSSSignal) = get_time_system_id(get_time_system(s))
+
+"""
+$(SIGNATURES)
+
+Get the human-readable name of a [`TimeSystem`](@ref) — `"GPS Time"` or
+`"Galileo System Time"`.
+
+The display counterpart to [`get_time_system_id`](@ref) — same granularity, but
+a `String` meant for log lines and user-facing output rather than a key to branch
+or dictionary on (prefer the `Symbol` id for that).
+
+Stated per time system rather than derived from the id, because the spelled-out
+names are the ICDs' own (`"Galileo System Time"`, Galileo OS SIS ICD §5.1.2) and
+bear no relation to the acronyms. Works on a time system or signal, instance or
+type, and folds to a compile-time constant.
+
+```julia-repl
+julia> get_time_system_name(GST())
+"Galileo System Time"
+
+julia> get_time_system_name(GPSL1CA)
+"GPS Time"
+```
+"""
+@inline get_time_system_name(::Type{GPST}) = "GPS Time"
+@inline get_time_system_name(::Type{GST}) = "Galileo System Time"
+@inline get_time_system_name(t::TimeSystem) = get_time_system_name(typeof(t))
+@inline get_time_system_name(::Type{S}) where {S<:AbstractGNSSSignal} =
+    get_time_system_name(get_time_system(S))
+@inline get_time_system_name(s::AbstractGNSSSignal) =
+    get_time_system_name(get_time_system(s))

--- a/test/bands.jl
+++ b/test/bands.jl
@@ -2,6 +2,12 @@
     @test @inferred(get_center_frequency(L1())) == 1_575_420_000Hz
     @test @inferred(get_center_frequency(L5())) == 1_176_450_000Hz
 
+    # Band type entry, as get_band_id / get_band_name accept.
+    @test @inferred(get_center_frequency(L1)) == 1_575_420_000Hz
+    @test @inferred(get_center_frequency(L2)) == 1_227_600_000Hz
+    @test @inferred(get_center_frequency(L5)) == 1_176_450_000Hz
+    @test get_center_frequency(L2()) == get_center_frequency(L2)
+
     @test @inferred(get_band(GPSL1CA())) isa L1
     @test @inferred(get_band(GPSL5I())) isa L5
     @test @inferred(get_band(GalileoE1B())) isa L1
@@ -30,4 +36,66 @@ end
 
     # Type-level signal dispatch works without constructing the signal.
     @test @inferred(get_band_id(GPSL1CA)) === :L1
+end
+
+@testset "get_band_name" begin
+    # On the band itself (instance and type).
+    @test @inferred(get_band_name(L1())) == "L1"
+    @test @inferred(get_band_name(L2())) == "L2"
+    @test @inferred(get_band_name(L5())) == "L5"
+    @test @inferred(get_band_name(L1)) == "L1"
+
+    # On a signal: the name follows the signal's band, so it is the RF band's
+    # label, not the constellation's — Galileo E1B reports "L1", not "E1".
+    @test @inferred(get_band_name(GPSL1CA())) == "L1"
+    @test @inferred(get_band_name(GalileoE1B())) == "L1"
+    @test @inferred(get_band_name(GPSL2CM())) == "L2"
+    @test @inferred(get_band_name(GPSL5I())) == "L5"
+    @test get_band_name(GalileoE1B()) == get_band_name(GPSL1CA()) == get_band_name(L1())
+
+    # Type-level signal dispatch works without constructing the signal.
+    @test @inferred(get_band_name(GalileoE5aI)) == "L5"
+
+    # Display counterpart of the id — same granularity, String instead of Symbol.
+    for band in (L1(), L2(), L5())
+        @test get_band_name(band) == String(get_band_id(band))
+    end
+
+    # Every band states its name as a literal rather than taking the derived
+    # fallback: that is what makes the call allocation-free and constant-foldable,
+    # and value equality alone cannot tell the two apart ("L1" == String(:L1)). So
+    # check the method dispatch actually reaches, not just what it returns.
+    derived = which(get_band_name, Tuple{Type{Band}})
+    for B in (L1, L2, L5)
+        @test which(get_band_name, Tuple{Type{B}}) !== derived
+        # Stated, but still exactly String() of the id — the two cannot drift apart.
+        @test get_band_name(B) == String(get_band_id(B))
+    end
+end
+
+# A band declared outside the package: it defines no accessor of its own, so both
+# the id and the name come from the fallbacks.
+struct TestOnlyBand <: Band end
+
+@testset "get_band_name fallback for a new Band" begin
+    @test get_band_id(TestOnlyBand) === :TestOnlyBand
+    @test get_band_name(TestOnlyBand) == "TestOnlyBand"
+    @test get_band_name(TestOnlyBand()) == "TestOnlyBand"
+    @test get_band_name(TestOnlyBand) == String(get_band_id(TestOnlyBand))
+    # It really is the derived fallback doing the work here.
+    @test which(get_band_name, Tuple{Type{TestOnlyBand}}) ===
+          which(get_band_name, Tuple{Type{Band}})
+end
+
+@testset "every band answers every band accessor" begin
+    # `TestOnlyBand` above is deliberately not in ALL_BANDS: the invariant is the
+    # package's to keep.
+    for B in ALL_BANDS
+        @test get_band_id(B) isa Symbol
+        @test get_band_name(B) isa String
+        # The carrier frequency is the one fact a band has to state for itself —
+        # on the band type, the entry get_band_id / get_band_name accept.
+        @test get_center_frequency(B) isa Frequency
+        @test get_center_frequency(B()) == get_center_frequency(B)
+    end
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -55,6 +55,16 @@ end
     @test get_signal_name(GPSL5I()) == "GPS L5-I"
     @test get_signal_name(GalileoE1B()) == "Galileo E1B"
     @test get_signal_name(GalileoE1C()) == "Galileo E1C"
+
+    # Type-level dispatch works without constructing the signal (which would read
+    # the code file from disk); the instance path forwards to it.
+    for S in ALL_SIGNALS
+        @test @inferred(get_signal_name(S)) isa String
+    end
+    @test get_signal_name(GPSL2CL) == "GPS L2CL"
+    @test get_signal_name(GalileoE1B_BOC11) == "Galileo E1B (BOC(1,1) approximation)"
+    @test get_signal_name(GPSL1CA()) == get_signal_name(GPSL1CA)
+    @test get_signal_name(GalileoE5aQ()) == get_signal_name(GalileoE5aQ)
 end
 
 @testset "get_signal_id" begin
@@ -77,6 +87,66 @@ end
     @test @inferred(get_constellation_id(GalileoE1B)) === :Galileo
     # Coarser than the signal id: two bands of one constellation share an id.
     @test get_constellation_id(GPSL1CA()) === get_constellation_id(GPSL5I())
+end
+
+@testset "get_constellation_name" begin
+    @test @inferred(get_constellation_name(GPSL1CA())) == "GPS"
+    @test @inferred(get_constellation_name(GPSL5I())) == "GPS"
+    @test @inferred(get_constellation_name(GalileoE1B())) == "Galileo"
+    @test @inferred(get_constellation_name(GalileoE5aI())) == "Galileo"
+    # Type-level dispatch works without constructing the signal.
+    @test @inferred(get_constellation_name(GalileoE1B)) == "Galileo"
+    # Coarser than the signal name: two bands of one constellation share a name.
+    @test get_constellation_name(GPSL1CA()) == get_constellation_name(GPSL5I())
+    # Display counterpart of the id — same granularity, String instead of Symbol.
+    @test get_constellation_name(GPSL1CA()) == String(get_constellation_id(GPSL1CA()))
+    @test get_constellation_name(GalileoE1B()) == String(get_constellation_id(GalileoE1B()))
+
+    # Every constellation states its name as a literal rather than taking the derived
+    # fallback: that is what makes the call allocation-free and constant-foldable, and
+    # value equality alone cannot tell the two apart ("GPS" == String(:GPS)). So check
+    # the method dispatch actually reaches, not just what it returns.
+    derived = which(get_constellation_name, Tuple{Type{AbstractGNSSSignal}})
+    for S in (GPSL1CA, GPSL5I, GalileoE1B, GalileoE5aQ)
+        @test which(get_constellation_name, Tuple{Type{S}}) !== derived
+        # Stated, but still exactly String() of the id — the two cannot drift apart.
+        @test get_constellation_name(S) == String(get_constellation_id(S))
+    end
+end
+
+# A signal of a constellation declared outside the package: it states only the
+# constellation id, so the name comes from the fallback.
+struct TestOnlySignal <: AbstractGNSSSignal{Matrix{Int16}} end
+GNSSSignals.get_constellation_id(::Type{TestOnlySignal}) = :TestOnlyGNSS
+
+@testset "get_constellation_name fallback for a new constellation" begin
+    @test get_constellation_id(TestOnlySignal) === :TestOnlyGNSS
+    @test get_constellation_name(TestOnlySignal) == "TestOnlyGNSS"
+    @test get_constellation_name(TestOnlySignal()) == "TestOnlyGNSS"
+    @test get_constellation_name(TestOnlySignal) ==
+          String(get_constellation_id(TestOnlySignal))
+    # It really is the derived fallback doing the work here.
+    @test which(get_constellation_name, Tuple{Type{TestOnlySignal}}) ===
+          which(get_constellation_name, Tuple{Type{AbstractGNSSSignal}})
+end
+
+@testset "every signal answers every identity accessor" begin
+    # A signal added later — a new constellation's, say — goes into ALL_SIGNALS
+    # and is held to the whole accessor layer here, so an omission surfaces as a
+    # test failure rather than a MethodError at someone's call site.
+    for S in ALL_SIGNALS
+        @test get_signal_id(S) isa Symbol
+        @test get_signal_name(S) isa String
+        @test get_constellation_id(S) isa Symbol
+        @test get_constellation_name(S) isa String
+        @test get_band(S) isa Band
+        @test get_band_id(S) isa Symbol
+        @test get_band_name(S) isa String
+        @test get_time_system(S) isa TimeSystem
+        @test get_time_system_id(S) isa Symbol
+        @test get_time_system_name(S) isa String
+        @test get_center_frequency(S) isa Frequency
+    end
 end
 
 @testset "SecondaryCode dispatch" begin
@@ -134,6 +204,20 @@ end
     # E1C is CBOC(−): the BOC(6,1) component is in anti-phase.
     @test get_modulation(GalileoE1C).boc2_sign == -1
     @test get_modulation(GalileoE1B).boc2_sign == 1
+
+    # The instance form forwards to the type form, so the modulation the code LUT
+    # is baked from (type form, via build_signal_lut) can never drift from the one
+    # get_code_spectrum reports (instance form).
+    #
+    # Equal values are not enough to pin that: a signal that states its modulation
+    # twice passes as long as the two copies still agree. So also require that the
+    # one generic forwarder is what dispatch actually reaches for every signal — a
+    # per-signal `get_modulation(::MySignal)` would intercept it here.
+    generic_forwarder = which(get_modulation, Tuple{AbstractGNSSSignal})
+    for S in ALL_SIGNALS
+        @test @inferred(get_modulation(S())) === get_modulation(S)
+        @test which(get_modulation, Tuple{S}) === generic_forwarder
+    end
 end
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,29 @@ import Unitful: Hz, MHz, Frequency
 import GNSSSignals: BOCsin, BOCcos, CBOC
 using CodecZlib: GzipDecompressorStream
 
+# Every concrete signal, band and time system the package defines. A type added
+# later must be appended here to be swept by the accessor-layer invariant tests
+# ("every signal answers every identity accessor" and friends). Test-suite
+# stand-ins (e.g. `TestOnlyBand`) stay out: the invariants are the package's to
+# keep.
+const ALL_SIGNALS = (
+    GPSL1CA,
+    GPSL1C_D,
+    GPSL1C_P,
+    GPSL2CM,
+    GPSL2CL,
+    GPSL5I,
+    GPSL5Q,
+    GalileoE1B,
+    GalileoE1B_BOC11,
+    GalileoE1C,
+    GalileoE1C_BOC11,
+    GalileoE5aI,
+    GalileoE5aQ,
+)
+const ALL_BANDS = (L1, L2, L5)
+const ALL_TIME_SYSTEMS = (GPST, GST)
+
 # Decode a hex-packed ±1 sample fixture (LSB-first packing into hex
 # nibbles, so 4 samples per nibble). Bit 0 of nibble `k` holds sample
 # `4k+1`, bit 3 holds sample `4k+4`. Bit value 0 → -1, 1 → +1.

--- a/test/time_systems.jl
+++ b/test/time_systems.jl
@@ -1,5 +1,5 @@
 using Dates: DateTime
-import Unitful: s
+import Unitful: s, Time
 
 @testset "Time systems" begin
     gps_signals = (GPSL1CA, GPSL1C_D, GPSL1C_P, GPSL2CM, GPSL2CL, GPSL5I, GPSL5Q)
@@ -61,4 +61,48 @@ import Unitful: s
     @test get_tai_offset(GPSL1CA) == get_tai_offset(GalileoE1B)
     @test get_system_start_time(GPSL1CA) != get_system_start_time(GalileoE1B)
     @test get_time_system(GPSL1CA) !== get_time_system(GalileoE1B)
+end
+
+@testset "get_time_system_id / get_time_system_name" begin
+    # On the time system itself (instance and type).
+    @test @inferred(get_time_system_id(GPST())) === :GPST
+    @test @inferred(get_time_system_id(GST())) === :GST
+    @test @inferred(get_time_system_id(GST)) === :GST
+    @test @inferred(get_time_system_name(GPST())) == "GPS Time"
+    @test @inferred(get_time_system_name(GST())) == "Galileo System Time"
+    @test @inferred(get_time_system_name(GPST)) == "GPS Time"
+
+    # On a signal: forwards through get_time_system, on type or instance.
+    for S in (GPSL1CA, GPSL2CM, GPSL5Q)
+        @test @inferred(get_time_system_id(S)) === :GPST
+        @test @inferred(get_time_system_name(S)) == "GPS Time"
+        @test get_time_system_id(S()) === get_time_system_id(S)
+        @test get_time_system_name(S()) == get_time_system_name(S)
+    end
+    for S in (GalileoE1B, GalileoE1C, GalileoE5aI)
+        @test @inferred(get_time_system_id(S)) === :GST
+        @test @inferred(get_time_system_name(S)) == "Galileo System Time"
+        @test get_time_system_id(S()) === get_time_system_id(S)
+        @test get_time_system_name(S()) == get_time_system_name(S)
+    end
+
+    # Every signal referenced to one scale shares id and name, across bands.
+    @test get_time_system_id(GPSL1CA) === get_time_system_id(GPSL5I)
+    @test get_time_system_id(GPSL1CA) !== get_time_system_id(GalileoE1B)
+    # The name is the ICD's spelled-out one, not the acronym.
+    @test get_time_system_name(GalileoE1B) != String(get_time_system_id(GalileoE1B))
+end
+
+@testset "every time system answers every time-system accessor" begin
+    for T in ALL_TIME_SYSTEMS
+        @test get_time_system_id(T) isa Symbol
+        # Deliberately the one name with no fallback to its id: the ICDs' spelled-out
+        # names bear no relation to the acronyms, so each system states its own and a
+        # new one has to say it here rather than report "BDT" and call it a name.
+        @test get_time_system_name(T) isa String
+        @test get_time_system_name(T) != String(get_time_system_id(T))
+        # The two constants a time scale is fixed by.
+        @test get_system_start_time(T()) isa DateTime
+        @test get_tai_offset(T()) isa Time
+    end
 end


### PR DESCRIPTION
Add the human-readable display accessors that were missing beside the existing ids, and fix the inconsistencies that gap exposed.

## New accessors

- **`get_constellation_name`** (`"GPS"` / `"Galileo"`) and **`get_band_name`** (`"L1"` / `"L2"` / `"L5"`) — the display counterparts to `get_constellation_id` and `get_band_id`. Each is stated as a literal (one method per band, one per constellation on the abstract signal type), so the call allocates nothing and folds to a compile-time constant, on an instance or a type. A `String(id)` fallback names a band or constellation declared elsewhere for free; that path allocates per call, which the docstrings explain. `get_band_name` is the RF band's label, not the constellation's: Galileo E1B reports `"L1"`, not `"E1"` — `get_signal_name` stays the ICD-specific name.
- **`get_time_system_id`** (`:GPST` / `:GST`) and **`get_time_system_name`** (`"GPS Time"` / `"Galileo System Time"`). `TimeSystem` was the one trait type with neither. The id defaults to `nameof` as `get_band_id` does; the name is stated per system with no fallback — the ICDs' spelled-out names bear no relation to the acronyms, so there is nothing to derive.

## De-duplication / consistency fixes

- **`get_signal_name` now dispatches on the signal type**, like every sibling accessor: `get_signal_name(GPSL1CA)` used to be a `MethodError`, and getting a name required constructing a signal (which reads a code file from disk). Purely additive — instance calls are unchanged.
- **One canonical docstring each for `get_signal_name` and `get_band`**, replacing eight near-identical per-signal copies that rendered the same sentence eight times on the API page (inconsistently — some with examples, some covered by a docstring naming a different signal).
- **Dropped the duplicated per-signal `get_modulation` instance methods.** All thirteen signals defined `get_modulation` twice (type + instance) although `modulation.jl` already forwards generically. The type form is what the code LUT is baked from; the instance form is what `get_code_spectrum` reports — editing one copy alone would have desynchronised generated samples from the reported spectrum. A test now pins that dispatch reaches the single generic forwarder for every signal.
- **`get_center_frequency` accepts a band type**: `get_band_id(L1)` worked while `get_center_frequency(L1)` was a `MethodError`.

## Tests

The identity accessors are swept over shared hand-listed `ALL_SIGNALS` / `ALL_BANDS` / `ALL_TIME_SYSTEMS` consts covering every type the package defines, so a forgotten accessor for a listed type surfaces as a test failure here instead of a `MethodError` at a caller. The name sweeps additionally pin, via the method table, that each package type states its name as a literal rather than reaching the allocating derived fallback — value equality alone cannot tell the two apart (`"L1" == String(:L1)`). Fallback behaviour for externally declared types is covered by `TestOnlyBand` / `TestOnlySignal` stand-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
