### PR TITLE
fix(code_lut): derive code amplitude from a PRN that has a code

### DIFF
--- a/src/code_lut.jl
+++ b/src/code_lut.jl
@@ -329,10 +329,17 @@ function build_signal_lut(modulation, codes::AbstractMatrix, sec::SecondaryCode;
         residual_perprn && (@inbounds secmat[:, prn] .= mc.secondary)
     end
     # Per-sample RMS amplitude of the baked code (see `SignalLUT.code_amplitude`). Computed
-    # once here from PRN 1's table — modulation-level and PRN-independent (all PRNs share the
-    # sub-carrier magnitude pattern; the primary only flips signs). Widen to `Int` before
-    # squaring: `abs2` on `Int8` overflows for CBOC's ±25 (25^2 = 625 wraps).
-    tbl = @view mc1.table.padded[1:mc1.table.length]
+    # once here from ONE PRN's table — modulation-level and PRN-independent (all PRNs share the
+    # sub-carrier magnitude pattern; the primary only flips signs). Not necessarily PRN 1: a
+    # signal whose PRN space has undefined slots stores those as an all-zero code (BeiDou B2b_I
+    # defines only PRN 6..58, so columns 1..5 and 59..63 are zero), and an all-zero column would
+    # give amplitude 0 for the whole signal. Take the first column that carries a code. Widen to
+    # `Int` before squaring: `abs2` on `Int8` overflows for CBOC's ±25 (25^2 = 625 wraps).
+    ref_prn = something(
+        findfirst(prn -> any(!iszero, @view padded[1:mc1.table.length, prn]), 1:num_prns),
+        1,
+    )
+    tbl = @view padded[1:mc1.table.length, ref_prn]
     code_amplitude = sqrt(sum(x -> abs2(Int(x)), tbl) / length(tbl))
     SignalLUT(
         padded,

--- a/test/beidou/b2b.jl
+++ b/test/beidou/b2b.jl
@@ -27,6 +27,20 @@ end
     end
 end
 
+@testset "BeiDou B2b-I code amplitude ignores the undefined PRN slots" begin
+    # PRN 1 is not in the ICD, so its stored code is all-zero. The amplitude is a
+    # signal-level (modulation) property and must come from a PRN that carries a code:
+    # BPSK(10) is a plain +/-1 code, so it is exactly 1.
+    b2b = BeiDouB2bI()
+    @test @inferred(get_code_amplitude(b2b)) == 1.0
+    lut = b2b.lut
+    @test all(iszero, @view lut.padded[1:lut.table_length, 1])   # the trap: PRN 1 is undefined
+    for prn = 6:58
+        tbl = Int.(@view lut.padded[1:lut.table_length, prn])
+        @test sqrt(sum(abs2, tbl) / length(tbl)) == 1.0
+    end
+end
+
 @testset "BeiDou B2b-I gen_code! produces a sampled BPSK(10) replica" begin
     b2b = BeiDouB2bI()
     samples_per_chip = 2

--- a/test/common.jl
+++ b/test/common.jl
@@ -18,6 +18,26 @@
     @test get_codes(signal) == signal.codes
 end
 
+@testset "get_code_amplitude is a positive, PRN-independent signal property" begin
+    # The amplitude is the RMS of ONE baked column, so it must not be read off a PRN slot
+    # the signal leaves undefined: BeiDou B2b_I defines only PRN 6..58 and stores the rest
+    # as an all-zero code, which used to make the whole signal report 0.0 — a divide-by-zero
+    # for the "divide the correlation by this" contract the accessor documents.
+    for S in ALL_SIGNALS
+        signal = S()
+        amp = get_code_amplitude(signal)
+        @test amp > 0.0
+        lut = signal.lut
+        # Every PRN that carries a code agrees with the signal-level value (only the signs
+        # differ between PRNs), and the value is the RMS of that column.
+        for prn in axes(lut.padded, 2)
+            tbl = Int.(@view lut.padded[1:lut.table_length, prn])
+            all(iszero, tbl) && continue
+            @test sqrt(sum(abs2, tbl) / length(tbl)) ≈ amp
+        end
+    end
+end
+
 @testset "get_carrier_phase_offset" begin
     # GPS civil signals ride the QUADRATURE carrier, lagging their band's P(Y)
     # in-phase reference by 90° → −π/2 (IS-GPS-200N §3.3.1.5.1, IS-GPS-705 §3.3.1.5).


### PR DESCRIPTION
`build_signal_lut` computes the per-sample RMS code amplitude once, off a single baked PRN column, on the grounds that the value is modulation-level and PRN-independent — all PRNs share the sub-carrier magnitude pattern and the primary code only flips signs. That reasoning is sound; reading it specifically off PRN 1 is not. It holds only where every PRN slot carries a code.

BeiDou B2b_I defines ranging codes for PRN 6..58 only (BDS-SIS-ICD-B2b-1.0 Table 5-1) and stores the undefined slots as an all-zero code, so columns 1..5 and 59..63 are zero. `BeiDouB2bI` therefore reported a code amplitude of 0.0 — the only implemented signal that did. That breaks the accessor's documented contract ("divide a correlation result by this"), which turns into a division by zero, and it is wrong for the 53 valid PRNs too: B2b_I is a plain ±1 BPSK(10) code, amplitude exactly 1.

The fix picks the reference column as the first PRN whose baked table is not all-zero, rather than PRN 1 unconditionally. Signals with a fully populated PRN space hit that on the first iteration, so their value is unchanged; the allocation is byte-identical, and the added scan costs ~11.5 µs at worst (B2b, five leading zero columns) against a 2.7 ms signal construction. Reading from `padded` rather than `mc1.table.padded` is what makes the column selectable at all — same data, indexed by PRN.

The gap went untested because the `get_code_amplitude` testset swept only Galileo E1B/E1C and GPS L1 C/A + L5I, all of which define every PRN. It now sweeps `ALL_SIGNALS`, asserting the amplitude is positive and that every code-carrying PRN's own column RMS matches the signal-level value — which is the PRN-independence claim the single-column shortcut rests on, checked instead of assumed. A B2b-specific test pins the trap directly: PRN 1's column is all-zero, PRN 6..58 each have RMS 1, and the signal reports 1.0.
